### PR TITLE
Enable edit link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -57,10 +57,7 @@ const config = {
           sidebarPath: "./sidebars.js",
           routeBasePath: "/",
           breadcrumbs: true,
-          // Please change this to your repo.
-          // Remove this to remove the "edit this page" links.
-          // editUrl:
-          //   "https://github.com/facebook/docusaurus/tree/main/packages/create-docusaurus/templates/shared/",
+          editUrl: "https://github.com/RevenueCat/docs/tree/main/",
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
## Motivation / Description

With the docs being public, we can link each page to the corresponding file in the repo

## Changes introduced

- Adds the edit url to the docusaurus config

## Linear ticket (if any)
## Additional comments
