### PR TITLE
Adds a `post_install` script to the KMP docs to work around a possible compilation error

### DIFF
--- a/code_blocks/getting-started/installation/kmp_8.ruby
+++ b/code_blocks/getting-started/installation/kmp_8.ruby
@@ -1,0 +1,16 @@
+target 'iosApp' do
+  use_frameworks!
+  platform :ios, '16.0'
+  pod 'shared', :path => '../shared', :platforms => :ios
+
+  # Add the following post_install script:
+  post_install do |installer|
+    installer.pods_project.targets.each do |target|
+      if target.name == 'shared'
+        target.build_configurations.each do |config|
+          config.build_settings.delete('ASSETCATALOG_COMPILER_APPICON_NAME')
+        end
+      end
+    end
+  end
+end 

--- a/docs/getting-started/installation/kotlin-multiplatform.mdx
+++ b/docs/getting-started/installation/kotlin-multiplatform.mdx
@@ -92,14 +92,15 @@ import cocoapodsGradle from "!!raw-loader!@site/code_blocks/getting-started/inst
     { type: 'kotlin', content: cocoapodsGradle, name: 'build.gradle.kts' }
 ]} />
 
-###### Missing app icon
-In this scenario, if you get a compilation error at the `CompileAssetCatalog` step complaining about a missing app icon, add the following `post_install` script to your iOS app target in your `Podfile`. For instance, if your Kotlin Multiplatform module is named `shared`, it would look something like this: 
+Finally, add the following `post_install` script to your iOS app target in your `Podfile`. For instance, if your Kotlin Multiplatform module is named `shared`, it should look something like this: 
 
 import podfilePostInstallContent from "!!raw-loader!@site/code_blocks/getting-started/installation/kmp_8.ruby";
 
 <RCCodeBlock tabs={[
     { type: 'ruby', content: podfilePostInstallContent, name: 'Podfile' }
 ]} />
+
+This avoids the compiler looking for an app icon in your Kotlin Multiplatform module.
 
 ### Set the correct launchMode for Android
 

--- a/docs/getting-started/installation/kotlin-multiplatform.mdx
+++ b/docs/getting-started/installation/kotlin-multiplatform.mdx
@@ -92,6 +92,15 @@ import cocoapodsGradle from "!!raw-loader!@site/code_blocks/getting-started/inst
     { type: 'kotlin', content: cocoapodsGradle, name: 'build.gradle.kts' }
 ]} />
 
+###### Missing app icon
+In this scenario, if you get a compilation error at the `CompileAssetCatalog` step complaining about a missing app icon, add the following `post_install` script to your iOS app target in your `Podfile`. For instance, if your Kotlin Multiplatform module is named `shared`, it would look something like this: 
+
+import podfilePostInstallContent from "!!raw-loader!@site/code_blocks/getting-started/installation/kmp_8.ruby";
+
+<RCCodeBlock tabs={[
+    { type: 'ruby', content: podfilePostInstallContent, name: 'Podfile' }
+]} />
+
 ### Set the correct launchMode for Android
 
 Depending on your user's payment method, they may be asked by Google Play to verify their purchase in their (banking) app. This means they will have to background your app and go to another app to verify the purchase. If your Activity's `launchMode` is set to anything other than `standard` or `singleTop`, backgrounding your app can cause the purchase to get cancelled. To avoid this, set the `launchMode` of your Activity to `standard` or `singleTop` in your Android app's `AndroidManifest.xml` file:


### PR DESCRIPTION
## Motivation / Description
We (@MarkVillacampa and myself) found a specific scenario in which iOS compilation might fail when integrating purchases-kmp. This was reported in https://github.com/RevenueCat/purchases-kmp/issues/275. 

## Changes introduced
Adds a `post_install` script workaround created by Mark, for when this compilation failure occurs. 