### PR TITLE
Add Cordova & Capacitor Code Blocks for Redeeming Win-Back Offers on Custom Paywalls

### DIFF
--- a/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-capacitor.ts
+++ b/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-capacitor.ts
@@ -1,0 +1,10 @@
+try {
+  const { eligibleWinBackOffers } =
+    await Purchases.getEligibleWinBackOffersForPackage({
+      aPackage: aPackage,
+    });
+
+  // TODO: display eligible win-back offers in your UI
+} catch (err) {
+  // TODO: handle the error in your UI
+}

--- a/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-cordova.js
+++ b/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-cordova.js
@@ -1,0 +1,9 @@
+Purchases.getEligibleWinBackOffersForPackage(
+  package,
+  (winBackOffers) => {
+    // TODO: display eligible win-back offers in your UI
+  },
+  (error) => {
+    // TODO: handle the error in your UI
+  }
+);

--- a/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-capacitor.ts
+++ b/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-capacitor.ts
@@ -1,0 +1,10 @@
+try {
+  const purchaseResult = await Purchases.purchasePackageWithWinBackOffer({
+    aPackage: aPackage,
+    winBackOffer: winBackOffer,
+  });
+
+  // TODO: Handle successful purchase in your UI
+} catch (err) {
+  // TODO: Handle failed purchase in your UI
+}

--- a/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-cordova.js
+++ b/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-cordova.js
@@ -1,0 +1,10 @@
+Purchases.purchasePackageWithWinBackOffer(
+  package,
+  winBackOffer,
+  ({ productIdentifier, customerInfo }) => {
+    // TODO: Handle successful purchase in your UI
+  },
+  ({ error, userCancelled }) => {
+    // TODO: Handle failed purchase in your UI
+  }
+);

--- a/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
+++ b/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
@@ -328,6 +328,8 @@ You can display win-back offers to subscribers on your paywall for users to rede
 import fetchEligibleWinbacks from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers.swift";
 import fetchEligibleWinbacksReactNative from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-react-native.ts";
 import fetchEligibleWinbacksFlutter from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-flutter.dart";
+import fetchEligibleWinbacksCordova from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-cordova.js";
+import fetchEligibleWinBacksCapacitor from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-fetch-eligible-winback-offers-capacitor.ts";
 
 <RCCodeBlock tabs={[
     {
@@ -344,6 +346,16 @@ import fetchEligibleWinbacksFlutter from "!!raw-loader!@site/code_blocks/subscri
         type: 'flutter',
         title: "Flutter",
         content: fetchEligibleWinbacksFlutter,
+    },
+    {
+        type: 'cordova',
+        title: "Cordova",
+        content: fetchEligibleWinbacksCordova,
+    },
+    {
+        type: 'capacitor',
+        title: "Capacitor",
+        content: fetchEligibleWinBacksCapacitor,
     }
 ]}/>
 
@@ -356,6 +368,8 @@ Once the user has selected a win-back offer that they'd like to redeem, you can 
 import purchaseWinbackOffer from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer.swift";
 import purchaseWinbackOfferReactNative from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-react-native.ts";
 import purchaseWinbackOfferFlutter from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-flutter.dart";
+import purchaseWinbackOfferCordova from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-cordova.js";
+import purchaseWinbackOfferCapacitor from "!!raw-loader!@site/code_blocks/subscription-guidance/subscription-offers/ios-winback-offers-purchase-winback-offer-capacitor.ts";
 
 <RCCodeBlock tabs={[
     {
@@ -372,6 +386,16 @@ import purchaseWinbackOfferFlutter from "!!raw-loader!@site/code_blocks/subscrip
         type: 'flutter',
         title: "Flutter",
         content: purchaseWinbackOfferFlutter,
+    },
+    {
+        type: 'cordova',
+        title: "Cordova",
+        content: purchaseWinbackOfferCordova,
+    },
+    {
+        type: 'capacitor',
+        title: "Capacitor",
+        content: purchaseWinbackOfferCapacitor,
     }
 ]}/>
 


### PR DESCRIPTION
## Changes introduced
This PR introduces code blocks demonstrating how developers can display & redeem win-back offers on custom paywalls in Capacitor and Cordova