### PR TITLE
[API v1] Make entitlement expiration date nullable

### DIFF
--- a/openapi-spec/api-v1.yaml
+++ b/openapi-spec/api-v1.yaml
@@ -942,8 +942,9 @@ components:
                 properties:
                   expires_date:
                     type: string
-                    description: Date when the entitlement expires / expired (in ISO 8601 format, may be in the past).
+                    description: Date when the entitlement expires / expired (in ISO 8601 format, may be in the past). `null` if it is a lifetime entitlement.
                     example: "2024-12-12T14:04:03Z"
+                    nullable: true
                   grace_period_expires_date:
                     type: string
                     description: Date when any potential grace period of the entitlement expires / expired (in ISO 8601 format, may be in the past). `null` if the Customer has never been in a grace period.


### PR DESCRIPTION
## Motivation / Description

Noticed expiration date was not marked as nullable in the OpenAPI v1.

We do say expiration date can be null for lifetime access entitlements in the `CustomerInfo` documentation, which is built from the get subscriber API endpoint:

https://github.com/RevenueCat/docs/blob/main/docs/customers/customer-info.mdx?plain=1#L291

## Changes introduced
## Linear ticket (if any)
## Additional comments
