### PR TITLE
Update .SetObserverMode calls in Unity

### DIFF
--- a/code_blocks/customers/user-ids_16.cs
+++ b/code_blocks/customers/user-ids_16.cs
@@ -8,7 +8,6 @@ Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfigurat
 Purchases.PurchasesConfiguration purchasesConfiguration =
     builder.SetUserDefaultsSuiteName("user_default")
     .SetDangerousSettings(new Purchases.DangerousSettings(false))
-    .SetObserverMode(true)
     .SetUseAmazon(false)
     .SetAppUserId(appUserId)
     .Build();

--- a/code_blocks/migrating-to-revenuecat/observer-mode_6.cs
+++ b/code_blocks/migrating-to-revenuecat/observer-mode_6.cs
@@ -2,10 +2,10 @@
 // If you'd like to do it programmatically instead, 
 // make sure to check "Use runtime setup" in the Unity Editor, and then:
 
-Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfiguration.Builder.Init(<api_key>);
+Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfiguration.Builder.Init(< api_key >);
 Purchases.PurchasesConfiguration purchasesConfiguration =
     builder.SetUserDefaultsSuiteName("user_default")
-    .SetObserverMode(true)
+    .SetPurchasesAreCompletedBy(Purchases.PurchasesAreCompletedBy.MyApp, Purchases.StoreKitVersion.StoreKit2)
     .SetAppUserId(appUserId)
     .Build();
 purchases.Configure(purchasesConfiguration);

--- a/docs/migrating-to-revenuecat/sdk-or-not/finishing-transactions.mdx
+++ b/docs/migrating-to-revenuecat/sdk-or-not/finishing-transactions.mdx
@@ -8,7 +8,7 @@ hidden: false
 
 If you already have your own in-app purchase handling logic in your app and want to start using RevenueCat alongside it, you might need to set the SDK configuration option that your app will **complete the purchases itself** (configuration option `purchasesAreCompletedBy`, see code below). Completing a purchase tells the device billing library that a purchase has been processed and can be discarded. RevenueCat does this by default, however, this may interfere with pre-existing purchase handling code in your app.
 
-If you set the SDK option that your app will complete purchases itself, you can still make use of most of RevenueCat's features, without replacing your existing purchase handling code.
+If you set the SDK option that your app will complete purchases itself, you can still make use of most of RevenueCat's features, without replacing your existing purchase handling code. If you're making purchases on iOS, be sure to set the `storeKitVersion` to the version of StoreKit you're using.
 
 :::info Observer mode
 The setting where your app completes purchases was formerly called "observer mode". Older versions of the SDK (currently including the iOS and cross-platform SDKs) still refer to this terminology.


### PR DESCRIPTION
## Motivation / Description
`.SetObserverMode()` was removed in the most recent major release of Unity. This PR updates references to it in the docs.

## Changes Introduced
- Removed `.SetObserverMode()` reference in `code_blocks/customers/user-ids_16.cs` - observer mode isn't needed in the spots of the documentation that this is shown in
- Replaced `.SetObserverMode()` with `.SetPurchasesAreCompletedBy()` in `code_blocks/migrating-to-revenuecat/observer-mode_6.cs`
- Added a note instructing the user to specify which StoreKit version they're using when specifying that purchases will be completed by their app