### PR TITLE
Update docs after enabling Trusted Entitlements by default

### DIFF
--- a/code_blocks/customers/trusted-entitlements-capacitor.ts
+++ b/code_blocks/customers/trusted-entitlements-capacitor.ts
@@ -1,4 +1,4 @@
 await Purchases.configure({ 
     apiKey: <public_api_key>, 
-    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.DISABLED
 });

--- a/code_blocks/customers/trusted-entitlements-rn.ts
+++ b/code_blocks/customers/trusted-entitlements-rn.ts
@@ -1,4 +1,4 @@
 await Purchases.configure({ 
     apiKey: <public_api_key>, 
-    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.INFORMATIONAL
+    entitlementVerificationMode: ENTITLEMENT_VERIFICATION_MODE.DISABLED
 });

--- a/code_blocks/customers/trusted-entitlements.cs
+++ b/code_blocks/customers/trusted-entitlements.cs
@@ -1,5 +1,5 @@
 Purchases.PurchasesConfiguration.Builder builder = Purchases.PurchasesConfiguration.Builder.Init(<public_api_key>);
 Purchases.PurchasesConfiguration purchasesConfiguration =
-    .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Informational)
+    .SetEntitlementVerificationMode(Purchases.EntitlementVerificationMode.Disabled)
     .Build();
 purchases.Configure(purchasesConfiguration);

--- a/code_blocks/customers/trusted-entitlements.dart
+++ b/code_blocks/customers/trusted-entitlements.dart
@@ -1,3 +1,3 @@
 PurchasesConfiguration configuration = PurchasesConfiguration(<public_api_key>);
-configuration.entitlementVerificationMode = EntitlementVerificationMode.informational;
+configuration.entitlementVerificationMode = EntitlementVerificationMode.disabled;
 await Purchases.configure(configuration);

--- a/code_blocks/customers/trusted-entitlements.kt
+++ b/code_blocks/customers/trusted-entitlements.kt
@@ -1,5 +1,5 @@
 Purchases.configure(
     PurchasesConfiguration.Builder(context, apiKey = <api_key>)
-        .entitlementVerificationMode(EntitlementVerificationMode.INFORMATIONAL)
+        .entitlementVerificationMode(EntitlementVerificationMode.DISABLED)
         .build()
 )

--- a/code_blocks/customers/trusted-entitlements.m
+++ b/code_blocks/customers/trusted-entitlements.m
@@ -1,2 +1,2 @@
 [RCPurchases configureWithConfigurationBuilder:[[RCConfiguration builderWithAPIKey:<api_key>]
-                        withEntitlementVerificationMode:RCEntitlementVerificationModeInformational]];
+                        withEntitlementVerificationMode:RCEntitlementVerificationModeDisabled]];

--- a/code_blocks/customers/trusted-entitlements.swift
+++ b/code_blocks/customers/trusted-entitlements.swift
@@ -1,4 +1,4 @@
 Purchases.configure(
     with: Configuration.Builder(withAPIKey: <api_key>)
-        .with(entitlementVerificationMode: .informational)
+        .with(entitlementVerificationMode: .disabled)
 )

--- a/docs/customers/trusted-entitlements.mdx
+++ b/docs/customers/trusted-entitlements.mdx
@@ -17,12 +17,7 @@ Trusted Entitlements is supported in iOS SDK version 4.25.0 and up, and Android 
 
 ### Configuration
 
-SDKs can be configured in one of 3 `EntitlementVerificationMode`'s:
-
-- Disabled (*default*): equivalent to no verification. Susceptible to request tampering.
-- Informational (*beta*): No behavior change, but the result of verification is included in `EntitlementInfos` / `EntitlementInfo`.
-- Enforced (*coming soon*): verification failures result in `ErrorCode.signatureVerificationFailed` error being thrown.
-
+Trusted Entitlements is enabled by default and it doesn't have any impact on performance or behavior by default. You can disable it by doing the following:
 
 
 import content1 from "!!raw-loader!@site/code_blocks/customers/trusted-entitlements.swift";
@@ -68,7 +63,7 @@ import content7 from "!!raw-loader!@site/code_blocks/customers/trusted-entitleme
 
 ### Verification
 
-When configuring the SDK with `EntitlementVerificationMode.informational`, `EntitlementInfo` contains the verification result:
+When Trusted Entitlements are enabled, `EntitlementInfo` contains the verification result:
 
 import content8 from "!!raw-loader!@site/code_blocks/customers/verification-result.swift";
 import content9 from "!!raw-loader!@site/code_blocks/customers/verification-result.m";
@@ -115,9 +110,9 @@ Additionally, verification errors are always forwarded to `Purchases.errorHandle
 
 ## Edge cases
 
-### Cache invalidation
+### Cache leftover
 
-Transitioning an app from `EntitlementVerificationMode.disabled` to `EntitlementVerificationMode.informational` means that cached data would not be verified. In order for a user to be able to rely on this new behavior, the SDKs invalidate caches when this change is detected, so that all subsequent data requests are guaranteed to have validation information.
+Transitioning an app from `EntitlementVerificationMode.disabled` to `EntitlementVerificationMode.informational` means that cached data would not be verified. The SDK will keep using that cached data, which should be updated with the result of the verification after a request to the RevenueCat servers is performed successfully. In this scenario, the `EntitlementInfo` will have a VerificationResult of "not requested". You may clear the CustomerInfo cache by calling the `Purchases/invalidateCustomerInfoCache()` method in the SDK if you want to avoid having unverified entitlements.
 
 ### Key replacement
 


### PR DESCRIPTION
## Motivation / Description
We are enabling Trusted Entitlements by default in the SDKs and changing the behavior, so the customer info cache is not cleared upon enabling, so the change of behavior is transparent to developers.

- [ ] Hold until SDK versions with the changes have shipped