### PR TITLE
Add Sandbox Apple Account creation location for iOS 18

### DIFF
--- a/docs/test-and-launch/sandbox/apple-app-store.mdx
+++ b/docs/test-and-launch/sandbox/apple-app-store.mdx
@@ -47,6 +47,8 @@ On iOS 12 or greater, navigate to `Settings > [Your Account] > App Store > Sandb
 
 On iOS 13 or greater, navigate to `Settings > App Store > Sandbox Account`.
 
+On iOS 18 or greater, navigate to `Settings > Developer > Sandbox Apple Account`.
+
 On macOS 11.5.2 or greater, navigate to `App Store > Preferences > Sandbox Account`.
 
 Add the sandbox account credentials that you previously created. (The sandbox account credentials won't appear until you've made a purchase using a sandbox account in a development build.)


### PR DESCRIPTION
## Motivation / Description

Add Sandbox Apple Account creation steps for newer iOS version.

## Changes introduced
## Linear ticket (if any)
## Additional comments

Found this solution [here](https://stackoverflow.com/a/79183072/875806). It says iOS 18.2. I'm on 18.2.1, and confirm this is correct now, but I do not know if it's true for 18.0.x or 18.1.x.
