### PR TITLE
Update in-app-purchase-key-configuration.mdx

### DIFF
--- a/docs/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.mdx
+++ b/docs/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration.mdx
@@ -7,7 +7,9 @@ hidden: false
 parentDoc: 649983b4c31b2e000a3c1859
 ---
 
-When setting up a new App Store App on RevenueCat, you will need to add an in-app purchase key. **This is a required configuration step**. Previously, adding an in-app purchase key was not required; the requirement was added because the in-app purchase key allows RevenueCat to provide accurate information about the country, currency, and pricing for purchases, which previously had to be estimated in some cases. In addition, the in-app purchase key is required for features like [Subscription offers](/subscription-guidance/subscription-offers/ios-subscription-offers#in-app-purchase-keys) or looking up customers by [Order ID](/dashboard-and-metrics/customer-lists#find-an-individual-customer).
+When setting up a new App Store App on RevenueCat, you will need to add an in-app purchase key. **This is a required configuration step. When using Purchases v5.x+ (i.e., StoreKit 2), transactions will fail to be recorded without this key being set**. This can result in users not accessing the purchases they are entitled to.  
+
+Previously, adding an in-app purchase key was not required; the requirement was added because the in-app purchase key allows RevenueCat to validate purchases, provide accurate information about the country, currency, and pricing for purchases, which previously had to be estimated in some cases. In addition, the in-app purchase key is required for features like [Subscription offers](/subscription-guidance/subscription-offers/ios-subscription-offers#in-app-purchase-keys) or looking up customers by [Order ID](/dashboard-and-metrics/customer-lists#find-an-individual-customer).
 
 :::warning Adding an in-app purchase key may change historic data
 Adding an in-app purchase key to an app with existing transactions may change historic data as we update previously estimated data with corrected data from Apple. As a result, you may see an increased number of updated transactions reported in your [Scheduled Data Exports](/integrations/scheduled-data-exports) and your historical [Charts](/dashboard-and-metrics/charts) data may also gradually update. 


### PR DESCRIPTION
## Motivation / Description
We don't say the key is required for purchase validation (https://github.com/RevenueCat/purchases-ios/releases/tag/5.0.0)

## Changes introduced
## Linear ticket (if any)
## Additional comments
