### PR TITLE
Update redemption link instructions for current hybrid SDKs

### DIFF
--- a/code_blocks/web/revenuecat-billing/redemption_flutter.dart
+++ b/code_blocks/web/revenuecat-billing/redemption_flutter.dart
@@ -1,0 +1,24 @@
+String redemptionUrl = 'YOUR_REDEMPTION_URL';
+
+final webPurchaseRedemption = await Purchases.parseAsWebPurchaseRedemption(redemptionUrl);
+
+if (webPurchaseRedemption != null) {
+    final result = await Purchases.redeemWebPurchase(webPurchaseRedemption);
+    result.when(
+        success: (customerInfo) {
+          // Redemption was successful and entitlements were granted to the user.
+        },
+        error: (error) {
+          // Redemption failed due to an error.
+        },
+        purchaseBelongsToOtherUser: () {
+          // The purchase associated to the link belongs to a different user and it cannot be redeemed.
+        },
+        invalidToken: () {
+          // The redemption link is invalid.
+        },
+        expired: (obfuscatedEmail) {
+          // The redemption link has expired. A new one has been sent to the user to the provided obfuscated email.
+        }
+    );
+}

--- a/code_blocks/web/revenuecat-billing/redemption_react.ts
+++ b/code_blocks/web/revenuecat-billing/redemption_react.ts
@@ -1,0 +1,26 @@
+String redemptionUrl = 'YOUR_REDEMPTION_URL';
+
+const webPurchaseRedemption = await Purchases.parseAsWebPurchaseRedemption(redemptionUrl);
+if (webPurchaseRedemption) {
+  const result = await Purchases.redeemWebPurchase(webPurchaseRedemption);
+  switch (result.result) {
+    case WebPurchaseRedemptionResultType.SUCCESS:
+      const customerInfo: CustomerInfo = result.customerInfo;
+      // Redemption was successful and entitlements were granted to the user.
+      break;
+    case WebPurchaseRedemptionResultType.ERROR:
+      const error: PurchasesError = result.error;
+      // Redemption failed due to an error.
+      break;
+    case WebPurchaseRedemptionResultType.PURCHASE_BELONGS_TO_OTHER_USER:
+      // The purchase associated to the link belongs to a different user and it cannot be redeemed.
+      break;
+    case WebPurchaseRedemptionResultType.INVALID_TOKEN:
+      // The redemption link is invalid.
+      break;
+    case WebPurchaseRedemptionResultType.EXPIRED:
+      const obfuscatedEmail: string = result.obfuscatedEmail;
+      // The redemption link has expired. A new one has been sent to the user to the provided obfuscated email.
+      break;
+  }
+}

--- a/code_blocks/web/revenuecat-billing/redemption_unity.cs
+++ b/code_blocks/web/revenuecat-billing/redemption_unity.cs
@@ -1,0 +1,32 @@
+string redemptionUrl = 'YOUR_REDEMPTION_URL';
+
+purchases.ParseAsWebPurchaseRedemption(redemptionUrl, (webPurchaseRedemption) => 
+{
+    if (webPurchaseRedemption != null)
+    {
+        purchases.RedeemWebPurchase(webPurchaseRedemption, (result) =>
+        {
+            switch (result) 
+            {
+                case Purchases.WebPurchaseRedemptionResult.Success success:
+                    Purchases.CustomerInfo customerInfo = success.CustomerInfo;
+                    // Redemption was successful and entitlements were granted to the user.
+                    break;
+                case Purchases.WebPurchaseRedemptionResult.RedemptionError error:
+                    Purchases.Error error = error.Error;
+                    // Redemption failed due to an error.
+                    break;
+                case Purchases.WebPurchaseRedemptionResult.InvalidToken:
+                    // The redemption link is invalid.
+                    break;
+                case Purchases.WebPurchaseRedemptionResult.PurchaseBelongsToOtherUser:
+                    // The purchase associated to the link belongs to a different user and it cannot be redeemed.
+                    break;
+                case Purchases.WebPurchaseRedemptionResult.Expired expired:
+                    string obfuscatedEmail = expired.ObfuscatedEmail;
+                    // The redemption link has expired. A new one has been sent to the user to the provided obfuscated email.
+                    break;
+            }
+        });
+    }
+});

--- a/docs/web/revenuecat-billing/redemption-links.mdx
+++ b/docs/web/revenuecat-billing/redemption-links.mdx
@@ -40,9 +40,9 @@ The SDK versions supporting Redemption Links are:
 | :----------------------- | :------------------------------- |
 | purchases-android        | 8.10.6 and above                 |
 | purchases-ios            | 5.14.1 and above                 |
-| purchases-flutter        | Coming soon                      |
-| purchases-unity          | Coming soon                      |
-| react-native-purchases   | Coming soon                      |
+| purchases-flutter        | 8.4.0 and above                  |
+| purchases-unity          | 7.4.1 and above                  |
+| react-native-purchases   | 8.5.0 and above                  |
 | purchases-kmp            | Coming soon                      |
 | purchases-capacitor      | Coming soon                      |
 
@@ -106,6 +106,42 @@ import androidRedemption1 from "!!raw-loader!@site/code_blocks/web/revenuecat-bi
 
 <RCCodeBlock tabs={[
     { type: 'kotlin', title: "Android Redemption", content: androidRedemption1, },
+]}/>
+
+##### Flutter
+
+In our Flutter SDK, you will need to obtain the deep link first. Please read the official docs on how to parse deep links: https://docs.flutter.dev/ui/navigation/deep-linking. You can use [app_links](https://pub.dev/packages/app_links) or similar libraries to obtain the deep link.
+
+Once you have the deep link, you can use the following snippet to perform the redemption:
+
+import flutterRedemption from "!!raw-loader!@site/code_blocks/web/revenuecat-billing/redemption_flutter.dart";
+
+<RCCodeBlock tabs={[
+    { type: 'dart', title: "Flutter Redemption", content: flutterRedemption, },
+]}/>
+
+##### React Native
+
+In our React Native SDK, you will need to obtain the deep link first. Please read the official docs on how to parse deep links: https://reactnavigation.org/docs/deep-linking/.
+
+Once you have the deep link, you can use the following snippet to perform the redemption:
+
+import reactNativeRedemption from "!!raw-loader!@site/code_blocks/web/revenuecat-billing/redemption_react.ts";
+
+<RCCodeBlock tabs={[
+    { type: 'typescript', title: "React Native Redemption", content: reactNativeRedemption, },
+]}/>
+
+##### Unity
+
+In our Unity SDK, you will need to obtain the deep link first. Please read the official docs on how to parse deep links: https://docs.unity3d.com/Manual/deep-linking.html.
+
+Once you have the deep link, you can use the following snippet to perform the redemption:
+
+import unityRedemption from "!!raw-loader!@site/code_blocks/web/revenuecat-billing/redemption_unity.cs";
+
+<RCCodeBlock tabs={[
+    { type: 'csharp', title: "Unity Redemption", content: unityRedemption, },
 ]}/>
 
 #### 4. Verify your setup


### PR DESCRIPTION
## Motivation / Description
This adds some instructions on how to use redemption links on the hybrids. Note that I haven't added specific instructions on how to obtain the deep link on each hybrid, since some of them might depend on the developer's implementation details. For now, I've just added links to the official deep link instructions on each of those.

This does not include KMP and Capacitor which still don't have support for redemption links.

## Changes introduced
## Linear ticket (if any)
## Additional comments
