### PR TITLE
Added explainer that RN footer paywalls aren't supported with new RN architecture

### DIFF
--- a/docs/tools/paywalls/displaying-paywalls.mdx
+++ b/docs/tools/paywalls/displaying-paywalls.mdx
@@ -267,6 +267,11 @@ There are also several listeners that can be used to handle the paywall lifecycl
 
 ### How to display a footer Paywall on your custom paywall
 
+:::warning
+`PaywallFooterContainerView` is not supported when [React Native's New Architecture](https://reactnative.dev/blog/2024/10/23/the-new-architecture-is-here) is enabled.
+Please see this [GitHub issue](https://github.com/RevenueCat/react-native-purchases/issues/1158#issuecomment-2613000475) for more information.
+:::
+
 RevenueCatUI also has a paywall variation that can be displayed as a footer below your custom paywall.
 This allows you to design your paywall exactly as you want with native components while still using RevenueCat UI to handle it.
 This is done by using `<RevenueCatUI.PaywallFooterContainerView>`.


### PR DESCRIPTION
## Motivation / Description
GitHub issue explaining this is [here](https://github.com/RevenueCat/react-native-purchases/issues/1158#issuecomment-2609385877).

Here's the update:

![Screenshot 2025-01-24 at 9 39 44 AM](https://github.com/user-attachments/assets/e809390d-e32f-4080-b3aa-e2de0afa5da5)