### PR TITLE
Add support for embedded docs mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -364,3 +364,12 @@ main .row {
     @apply w-full grid grid-cols-1 gap-6 xl:grid-cols-2;
   }
 }
+
+/* See src/theme/Root.js > useEmbedMode */
+body[data-embed="true"] {
+  nav,
+  aside.theme-doc-sidebar-container,
+  footer {
+    display: none !important;
+  }
+}

--- a/src/theme/Root.js
+++ b/src/theme/Root.js
@@ -1,0 +1,36 @@
+import React, { useEffect } from "react";
+
+/**
+ * Hide navigation elements when embedded in the RevenueCat app in an iframe.
+ *
+ * The initial URL must include an `?embed=true` query parameter. This is set to
+ * sessionStorage so that any navigations within the embedded window keep the
+ * embed context.
+ *
+ * Session storage is not shared across tabs, so this will not affect anything
+ * else.
+ */
+const useEmbedMode = () => {
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const searchParams = new URLSearchParams(window.location.search);
+
+    if (searchParams.get("embed") === "true") {
+      sessionStorage.setItem("embed", "true");
+    }
+
+    if (sessionStorage.getItem("embed") === "true") {
+      // see src/css/custom.css
+      document.body.setAttribute("data-embed", "true");
+    }
+  }, []);
+};
+
+export default function Root({ children }) {
+  useEmbedMode();
+
+  return children;
+}


### PR DESCRIPTION
## Motivation / Description

This allows documentation pages to be embedded within an iframe without navigation elements.

Adding `?embed=true` to the page turns this on.

## Changes introduced

A hook that swaps the styles based on that param. I used session storage for temporary persistence, so that clicking on links still works without resetting the embed mode setting.

## Linear ticket (if any)

References COFE-200

## Additional comments

\-
