### PR TITLE
Add info box about version availability

### DIFF
--- a/docs/customers/trusted-entitlements.mdx
+++ b/docs/customers/trusted-entitlements.mdx
@@ -19,6 +19,9 @@ Trusted Entitlements is supported in iOS SDK version 4.25.0 and up, and Android 
 
 Trusted Entitlements is enabled by default and it doesn't have any impact on performance or behavior by default. You can disable it by doing the following:
 
+:::info
+Trusted Entitlements are disabled by default for versions under 5.15.0 in iOS and 8.11.0 in Android.
+:::
 
 import content1 from "!!raw-loader!@site/code_blocks/customers/trusted-entitlements.swift";
 import content2 from "!!raw-loader!@site/code_blocks/customers/trusted-entitlements.m";


### PR DESCRIPTION
## Motivation / Description
Trusted entitlements used to be disabled by default but it changed recently. The docs reflect that change but don't mentioned that if you are on an older version, it's disabled. See conversation [here](https://revenuecat.slack.com/archives/C030CB80FQ9/p1737988516485639).


