### PR TITLE
Updated old paywall versions

### DIFF
--- a/code_blocks/getting-started/installation/flutter_1.yaml
+++ b/code_blocks/getting-started/installation/flutter_1.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  purchases_flutter: ^6.0.0
+  purchases_flutter: <latest version>

--- a/code_blocks/getting-started/installation/kmp_1.toml
+++ b/code_blocks/getting-started/installation/kmp_1.toml
@@ -1,5 +1,5 @@
 [versions] 
-purchases-kmp = "1.1.0+13.3.0"
+purchases-kmp = "<latest version>"
 
 [libraries]
 # Required

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -12,9 +12,9 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ### Installation
 
-Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
-
 [![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+
+Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
 
 import content from "!!raw-loader!@site/code_blocks/getting-started/installation/android_1.groovy";
 

--- a/docs/getting-started/installation/capacitor.mdx
+++ b/docs/getting-started/installation/capacitor.mdx
@@ -10,6 +10,8 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-capacitor.svg?style=flat)](https://github.com/RevenueCat/purchases-capacitor/releases)
+
 import content from "!!raw-loader!@site/code_blocks/getting-started/installation/capacitor_add_plugin.shell";
 
 <RCCodeBlock tabs={[

--- a/docs/getting-started/installation/flutter.mdx
+++ b/docs/getting-started/installation/flutter.mdx
@@ -15,6 +15,8 @@ Minimum target: iOS 11.0+
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/)  (and run an implicit dart pub get):
 
 import content from "!!raw-loader!@site/code_blocks/getting-started/installation/flutter_1.yaml";

--- a/docs/getting-started/installation/ios.mdx
+++ b/docs/getting-started/installation/ios.mdx
@@ -10,6 +10,8 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+
 RevenueCat for iOS can be installed either via [CocoaPods](/getting-started/installation/ios#section-install-via-cocoapods), [Carthage](ios#section-install-via-carthage), or [Swift Package Manager](/getting-started/installation/ios#section-install-via-swift-package-manager). 
 
 :::info

--- a/docs/getting-started/installation/reactnative.mdx
+++ b/docs/getting-started/installation/reactnative.mdx
@@ -10,6 +10,8 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+
 Make sure that the deployment target for iOS is at least 13.4 and Android is at least 6.0 (API 23) [as defined here](https://github.com/facebook/react-native#-requirements). 
 
 ### Option 1: React-Native package

--- a/docs/getting-started/installation/roku.mdx
+++ b/docs/getting-started/installation/roku.mdx
@@ -71,6 +71,8 @@ The Roku channel ID is required for supporting multiple channels on a single Rok
 After you have configured the Roku Store app on RevenueCat, you should [create your in-channel products](/getting-started/entitlements/roku-products) and then follow RevenueCat's regular setup of [entitlements, products, and offerings](/getting-started/entitlements).
 
 ## Installing the SDK
+
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-roku.svg?style=flat)](https://github.com/RevenueCat/purchases-roku/releases)
 1. Clone the repository:
 
 import rokuClone from "!!raw-loader!@site/code_blocks/getting-started/installation/configuring-roku_1.shell";

--- a/docs/getting-started/installation/unity.mdx
+++ b/docs/getting-started/installation/unity.mdx
@@ -10,6 +10,8 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-unity.svg?style=flat)](https://github.com/RevenueCat/purchases-unity/releases)
+
 We provide 2 ways to install our SDK: via Unity Package Manager (UPM) in the OpenUPM registry, or as a `.unitypackage`.
 
 ### Option 1 (recommended): Install using OpenUPM

--- a/docs/getting-started/installation/web-sdk.mdx
+++ b/docs/getting-started/installation/web-sdk.mdx
@@ -16,6 +16,8 @@ RevenueCat Billing and the RevenueCat Web SDK are currently in beta.
 
 ## Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-js.svg?style=flat)](https://github.com/RevenueCat/purchases-js/releases)
+
 To install the RevenueCat Web SDK, add the `@revenuecat/purchases-js` package to your project using the package manager of your choice:
 
 import npmContent from "!!raw-loader!@site/code_blocks/_projects/rc-billing/installation-npm.shell";

--- a/docs/tools/paywalls/installation.mdx
+++ b/docs/tools/paywalls/installation.mdx
@@ -28,6 +28,8 @@ Support for macOS, tvOS, and other platforms is coming soon!
 
 ## Native iOS Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+
 ### Using SPM:
 
 #### If you already have `RevenueCat` in your project:
@@ -70,48 +72,48 @@ pod 'RevenueCatUI'
 
 ## Native Android Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+
 1. Add `RevenueCatUI`:
 ```groovy build.gradle
-implementation 'com.revenuecat.purchases:purchases:7.1.0'
-implementation 'com.revenuecat.purchases:purchases-ui:7.1.0'
+implementation 'com.revenuecat.purchases:purchases:<latest version>'
+implementation 'com.revenuecat.purchases:purchases-ui:<latest version>'
 ```
 
-:::danger
-Android paywalls is currently behind an experimental flag (`ExperimentalPreviewRevenueCatUIPurchasesAPI`).
-
-It is safe to release app updates with it. We guarantee that paywalls will continue to work and any changes will always be backwards compatible.
-
-They are stable, but migration steps may be required in the future. We'll do our best to minimize any changes you have to make.
-:::
-
 ## React Native Installation
+
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
 
 - Update your `package.json` to include `react-native-purchases-ui`:
 ```json
 {
   "dependencies": {
-    "react-native-purchases": "7.15.0",
-    "react-native-purchases-ui": "7.15.0"
+    "react-native-purchases": "<latest version>",
+    "react-native-purchases-ui": "<latest version>"
   }
 }
 ```
 
 ## Flutter Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+
 - Add `purchases-ui-flutter` in your `pubspec.yaml`:
 ```yaml
 dependencies:
-  purchases_flutter: 6.15.0
-  purchases_ui_flutter: 6.15.0
+  purchases_flutter: <latest version>
+  purchases_ui_flutter: <latest version>
 ```
 - For Android, you need to change your `MainActivity` to subclass `FlutterFragmentActivity` instead of `FlutterActivity`.
 
 ## Kotlin Multiplatform Installation
 
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
+
 Add the following Maven coordinates to your `libs.versions.toml`:
 ```toml libs.versions.toml
 [versions] 
-purchases-kmp = "1.1.0+13.3.0"
+purchases-kmp = "<latest version>"
 
 [libraries]
 purchases-core = { module = "com.revenuecat.purchases:purchases-kmp-core", version.ref = "purchases-kmp" }


### PR DESCRIPTION
## Motivation / Description
We had SDK versions listed in the paywall installation instructions. I added badges for all of our SDKs to show the latest versions, and updated the code snippets to not explicitly show old versions. They now show `"<latest version>"`, with the badge directly above it.

For example:
<img width="844" alt="Screenshot 2025-01-29 at 9 19 53 AM" src="https://github.com/user-attachments/assets/fb351a7b-9ba6-47ac-ace5-045c191d2e87" />

I also added badges to the "Installing the SDK" pages for each SDK, and removed an old warning for Android in paywalls.