### PR TITLE
Add that revenue will always be reported in USD but can find the orig…

### DIFF
--- a/docs/integrations/third-party-integrations/amplitude.mdx
+++ b/docs/integrations/third-party-integrations/amplitude.mdx
@@ -44,7 +44,7 @@ The Amplitude integration tracks the following events:
 | Product Change           | rc_product_change_event          | A subscriber has changed the product of their subscription. This does not mean the new subscription is in effect immediately. See [Managing Subscriptions](/subscription-guidance/managing-subscriptions) for more details on updates, downgrades, and crossgrades.                                                                                                                                                                                                                                                                                          | ✅         | ✅          | ❌      | ✅      | ❌     |
 
 
-For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in Amplitude.
+For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in Amplitude. Bear in mind that revenue will always be reported in USD. If it's been made with a different currency, we'll automatically convert it. You can find the currency of the original transaction in the `currency` field of the event.
 
 ## Setup
 

--- a/docs/integrations/third-party-integrations/iterable.mdx
+++ b/docs/integrations/third-party-integrations/iterable.mdx
@@ -43,7 +43,7 @@ The Iterable integration tracks the following events:
 | Billing Issue               | Custom              | rc_billing_issue_event         | There has been a problem trying to charge the subscriber. This does not mean the subscription has expired. Can be safely ignored if listening to CANCELLATION event + cancel_reason=BILLING_ERROR.                                                                      | ✅         | ✅          | ✅      | ✅      | ❌     |
 | Product Change              | Custom              | rc_product_change_event        | A subscriber has changed the product of their subscription. This does not mean the new subscription is in effect immediately. See [Managing Subscriptions](/subscription-guidance/managing-subscriptions) for more details on updates, downgrades, and crossgrades. | ✅         | ✅          | ❌      | ✅      | ❌     |
 
-For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in Iterable.
+For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in Iterable. Bear in mind that revenue will always be reported in USD. If it's been made with a different currency, we'll automatically convert it. You can find the currency of the original transaction in the `currency` field of the event.
 
 ## Setup
 

--- a/docs/integrations/third-party-integrations/posthog.mdx
+++ b/docs/integrations/third-party-integrations/posthog.mdx
@@ -43,7 +43,7 @@ The PostHog integration tracks the following events:
 | Billing Issues            | rc_billing_issue_event             | There has been a problem trying to charge the subscriber. This does not mean the subscription has expired. Can be safely ignored if listening to CANCELLATION event + cancel_reason=BILLING_ERROR.                                                                                                                                          | ✅        | ✅         | ✅     | ✅     | ❌    |
 | Product Change            | rc_product_change_event            | A subscriber has changed the product of their subscription. This does not mean the new subscription is in effect immediately. See [Managing Subscriptions](/subscription-guidance/managing-subscriptions) for more details on updates, downgrades, and crossgrades.                                                                         | ✅        | ✅         | ❌     | ✅     | ❌    |
 
-For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in PostHog.
+For events that have revenue, such as trial conversions and renewals, RevenueCat will automatically record this amount along with the event in PostHog. Bear in mind that revenue will always be reported in USD. If it's been made with a different currency, we'll automatically convert it. You can find the currency of the original transaction in the `currency` field of the event.
 
 ## Setup
 


### PR DESCRIPTION
For these 3 integrations, we always send the price converted to USD but we send the original currency. It is misleading and some customers believe that the revenue is in such currency. 
This aims to clarify it and make sure developers know that is being send in USD.