### PR TITLE
Added Android billing permission callout in Flutter & Sandbox

### DIFF
--- a/docs/getting-started/installation/flutter.mdx
+++ b/docs/getting-started/installation/flutter.mdx
@@ -74,6 +74,22 @@ Don't forget to enable the In-App Purchase capability for your iOS project under
 
 ![](/images/66c301a-65db383-Screen_Shot_2018-12-18_at_9.15.09_AM_51ae7051850be013d83c1e9a8f107b61.png "65db383-Screen_Shot_2018-12-18_at_9.15.09_AM.png")
 
+:::info Include BILLING permission for Android projects
+Don't forget to include the `BILLING` permission in your AndroidManifest.xml file
+:::
+
+import reactNativeXmlContent from "!!raw-loader!@site/code_blocks/getting-started/installation/reactnative_8.xml";
+
+<RCCodeBlock
+  tabs={[
+    {
+      type: "xml",
+      content: reactNativeXmlContent,
+      name: "AndroidManifest.xml",
+    },
+  ]}
+/>
+
 :::warning
 If you're using other plugins like [mobx](https://pub.dev/packages/flutter_mobx), you may run into conflicts with types from other plugins having the same name as those defined in `purchases_flutter`.<br/>
 If this happens, you can resolve the ambiguity in the types by adding an import alias, for example:

--- a/docs/test-and-launch/sandbox/google-play-store.mdx
+++ b/docs/test-and-launch/sandbox/google-play-store.mdx
@@ -67,6 +67,22 @@ If your app is completely new, you may need to make your app available to your c
 
 Generate a signed APK or use Android App Bundle to upload a signed APK to the alpha track you just created. You don’t even need to roll out the release. Just upload the APK. You can find more information about this in this support article [https://support.google.com/googleplay/android-developer/answer/7159011](https://support.google.com/googleplay/android-developer/answer/7159011)
 
+:::info Include BILLING permission for Android projects
+You may need to include the `BILLING` permission in your AndroidManifest.xml file in order to unlock product creating in Google Play Console.
+:::
+
+import reactNativeXmlContent from "!!raw-loader!@site/code_blocks/getting-started/installation/reactnative_8.xml";
+
+<RCCodeBlock
+  tabs={[
+    {
+      type: "xml",
+      content: reactNativeXmlContent,
+      name: "AndroidManifest.xml",
+    },
+  ]}
+/>
+
 ## Make a purchase
 
 Before you can make a purchase, make sure your release has been approved and available.


### PR DESCRIPTION
## Motivation / Description
It looks like Flutter projects may require the Android BILLING permission to initially upload the APK to Google. This unlocks product configuration in Google Play. I also added a similar callout to the Google Play Sandbox document.

<img width="832" alt="Screenshot 2025-01-30 at 11 03 47 AM" src="https://github.com/user-attachments/assets/372653cb-f8f8-4554-9bf6-28647f6e6cbf" />