### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# This file is used to ignore commits in the GitHub blame view
+#   https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
+# Use the following command to use this ignoreRevsFile locally:
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# 2025-01-27 Add Prettier (#614)
+23877548a1cb83f9dccf14c7069d5db79b42ffb3
+# 2025-01-30 Reformat .md/.mdx files with Prettier (#620)
+31ba54ad2b3944f48d21d8292bc62f02b4d07aeb


### PR DESCRIPTION
## Motivation / Description

I reformatted a lot of files in #614 and #620 when adding Prettier. This adds a `.git-blame-ignore-revs` file ignoring them [^1]

[^1]: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view

## Changes introduced

## Linear ticket (if any)

## Additional comments

<!-- av pr metadata
This information is embedded by the av CLI when creating PRs to track the status of stacks when using Aviator. Please do not delete or edit this section of the PR.
```
{"parent":"main","parentHead":"","trunk":"main"}
```
-->
