### PR TITLE
Ensures missing SDKs are listed on the 'Troubleshooting SDKs' page. 

### DIFF
--- a/docs/test-and-launch/debugging/troubleshooting-the-sdks.mdx
+++ b/docs/test-and-launch/debugging/troubleshooting-the-sdks.mdx
@@ -19,10 +19,14 @@ You can find the latest version of our SDKs here:
 
 - [iOS](https://github.com/revenuecat/purchases-ios/releases/latest)
 - [Android](https://github.com/revenuecat/purchases-android/releases/latest)
-- [Flutter](https://github.com/revenuecat/purchases-flutter/releases/latest)
 - [React-Native](https://github.com/revenuecat/react-native-purchases/releases/latest)
+- [Flutter](https://github.com/revenuecat/purchases-flutter/releases/latest)
+- [Kotlin Multiplatform](https://github.com/RevenueCat/purchases-kmp)
 - [Cordova](https://github.com/revenuecat/cordova-plugin-purchases/releases/latest)
+- [Capacitor](https://github.com/RevenueCat/purchases-capacitor)
 - [Unity](https://github.com/revenuecat/purchases-unity/releases/latest)
+- [Web](https://github.com/RevenueCat/purchases-js)
+- [Roku](https://github.com/RevenueCat/purchases-roku)
 - [Ionic Native](https://ionicframework.com/docs/native/purchases)
 
 # Issues when compiling or archiving


### PR DESCRIPTION
## Motivation / Description
The "Troubleshooting SDKs" page does not list the SDKs that we list on the "Installing the SDK" docs page.

## Changes introduced
* Ensures missing SDKs are listed on the 'Troubleshooting SDKs' page. 
* Reorders to better match the order of SDKs listed on the "Installing the SDK."

## Linear ticket (if any)
NA

## Additional comments
NA
