### PR TITLE
Add price accuracy to why Google Server Notifications should be enabled

### DIFF
--- a/docs/platform-resources/server-notifications/google-server-notifications.md
+++ b/docs/platform-resources/server-notifications/google-server-notifications.md
@@ -5,7 +5,7 @@ excerpt: Sending Google Play server notifications to RevenueCat
 hidden: false
 ---
 
-RevenueCat does not require anything further than service credentials to communicate with Google, but setting up [real-time server notifications](https://developer.android.com/google/play/billing/realtime_developer_notifications) is a strongly recommended process that can improve price accuracy, speed up webhook and integration delivery times and reduce lag time for [Charts](/dashboard-and-metrics/charts).
+RevenueCat does not require anything other than service credentials to communicate with Google, but setting up [real-time server notifications](https://developer.android.com/google/play/billing/realtime_developer_notifications) is a strongly recommended process that can improve price accuracy, speed up webhook and integration delivery times, and reduce lag time for [Charts](/dashboard-and-metrics/charts).
 
 <YouTubeEmbed videoId="hWub02tNdJ0" title="Setting Up Google Real-Time Developer Notifications" />
 

--- a/docs/platform-resources/server-notifications/google-server-notifications.md
+++ b/docs/platform-resources/server-notifications/google-server-notifications.md
@@ -5,7 +5,7 @@ excerpt: Sending Google Play server notifications to RevenueCat
 hidden: false
 ---
 
-RevenueCat does not require anything further than service credentials to communicate with Google, but setting up [real-time server notifications](https://developer.android.com/google/play/billing/realtime_developer_notifications) is a recommended process that can speed up webhook and integration delivery times and reduce lag time for [Charts](/dashboard-and-metrics/charts).
+RevenueCat does not require anything further than service credentials to communicate with Google, but setting up [real-time server notifications](https://developer.android.com/google/play/billing/realtime_developer_notifications) is a strongly recommended process that can improve price accuracy, speed up webhook and integration delivery times and reduce lag time for [Charts](/dashboard-and-metrics/charts).
 
 <YouTubeEmbed videoId="hWub02tNdJ0" title="Setting Up Google Real-Time Developer Notifications" />
 


### PR DESCRIPTION
## Motivation / Description

This ticket demonstrates that server notifications can sometimes cause less than accurate pricing in Google: https://linear.app/revenuecat/issue/DENG-1096/google-play-transaction-discrepancy-rc-reporting-more-than-the-google#comment-db68abaa

We want to strongly advise developers to enable it for pricing accuracy too. 

## Changes introduced

## Linear ticket (if any)

## Additional comments
