### PR TITLE
Remove flaky sandbox win-back message testing warning

### DIFF
--- a/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
+++ b/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
@@ -310,10 +310,6 @@ If you're running other win-back campaigns on non-iOS stores, we recommend defer
 
 Repeat steps 5-17 to test redeeming win-back offers multiple times.
 
-:::warning
-In our testing, we've found that this method of testing does not work 100% of the time, and that sometimes there can be a noticeable delay between when you leave the Settings app and when the win-back offer redemption sheet is displayed.
-:::
-
 #### Redeeming a Win-Back Offer Through the App Store with Streamlined Purchasing Disabled
 
 Purchasing win-back offers through the App Store uses Streamlined Purchasing by default, meaning that subscribers can complete the entire win-back offer redemption flow in the App Store. If you require users to perform an action in your app before making a purchase, like signing in, you can disable Streamlined Purchasing. When Streamlined Purchasing is disabled, subscribers will start the win-back redemption flow in the App Store, but will complete the flow in your app. Support for redeeming win-back offers from the App Store with Streamlined Purchasing disabled is available in the iOS SDK versions 5.9.0+.


### PR DESCRIPTION
## Motivation / Description
We've re-tested the win-back message screen in sandbox and found that it doesn't appear to be flaky any longer, so this removes the flakiness warning

## Changes introduced
Remove warning about the win-back storekit message not appearing 100% of the time