### PR TITLE
correctly name objc code block

### DIFF
--- a/docs/getting-started/restoring-purchases.mdx
+++ b/docs/getting-started/restoring-purchases.mdx
@@ -23,7 +23,7 @@ import kmpContent from "!!raw-loader!@site/code_blocks/getting-started/restoring
 <RCCodeBlock
   tabs={[
     { type: "swift", content: swiftContent },
-    { type: "objectivec", content: objectiveCContent },
+    { type: "objectivec", content: objectiveCContent, name: "Objective-C" },
     { type: "kotlin", content: kotlinContent },
     { type: "kotlin", content: kmpContent, name: "Kotlin Multiplatform" },
     { type: "java", content: javaContent },


### PR DESCRIPTION
## Motivation / Description
For some reason, the Obj-C code block under restoring purchases is named "Code" instead of "Objective-C". This fixes the issue by providing an explicit name for the code block.

Page link: https://www.revenuecat.com/docs/getting-started/restoring-purchases

### Before
<img width="903" alt="Screenshot 2025-02-18 at 9 36 28 AM" src="https://github.com/user-attachments/assets/005fd788-e43c-47e7-9b26-021f4a3a9db1" />

### After
<img width="932" alt="Screenshot 2025-02-18 at 9 43 04 AM" src="https://github.com/user-attachments/assets/5d391569-ea61-4d02-85d3-0cf3ecb540a0" />

