### PR TITLE
Add redemption links docs for missing hybrids

### DIFF
--- a/code_blocks/web/web-billing/redemption_capacitor.ts
+++ b/code_blocks/web/web-billing/redemption_capacitor.ts
@@ -1,0 +1,26 @@
+String redemptionUrl = 'YOUR_REDEMPTION_URL';
+
+const { webPurchaseRedemption } = await Purchases.parseAsWebPurchaseRedemption({ urlString: url });
+if (webPurchaseRedemption) {
+  const result = await Purchases.redeemWebPurchase({ webPurchaseRedemption: webPurchaseRedemption });
+  switch (result.result) {
+    case WebPurchaseRedemptionResultType.SUCCESS:
+      const customerInfo: CustomerInfo = result.customerInfo;
+      // Redemption was successful and entitlements were granted to the user.
+      break;
+    case WebPurchaseRedemptionResultType.ERROR:
+      const error: PurchasesError = result.error;
+      // Redemption failed due to an error.
+      break;
+    case WebPurchaseRedemptionResultType.PURCHASE_BELONGS_TO_OTHER_USER:
+      // The purchase associated to the link belongs to a different user and it cannot be redeemed.
+      break;
+    case WebPurchaseRedemptionResultType.INVALID_TOKEN:
+      // The redemption link is invalid.
+      break;
+    case WebPurchaseRedemptionResultType.EXPIRED:
+      const obfuscatedEmail: string = result.obfuscatedEmail;
+      // The redemption link has expired. A new one has been sent to the user to the provided obfuscated email.
+      break;
+  }
+}

--- a/code_blocks/web/web-billing/redemption_kmp.kt
+++ b/code_blocks/web/web-billing/redemption_kmp.kt
@@ -1,0 +1,26 @@
+val webPurchaseRedemption = Purchases.parseAsWebPurchaseRedemption(urlString)
+
+if (webPurchaseRedemption != null && Purchases.isConfigured) {
+    Purchases.sharedInstance.redeemWebPurchase(webPurchaseRedemption) { result ->
+        when (result) {
+            is RedeemWebPurchaseListener.Result.Error -> {
+                val error: PurchasesError = result.error
+                // Redemption failed due to an error.
+            }
+            is RedeemWebPurchaseListener.Result.Expired -> {
+                val obfuscatedEmail: String = result.obfuscatedEmail
+                // The redemption link has expired. A new one has been sent to the user to the provided obfuscated email.
+            }
+            RedeemWebPurchaseListener.Result.InvalidToken -> {
+                // The redemption link is invalid.
+            }
+            RedeemWebPurchaseListener.Result.PurchaseBelongsToOtherUser -> {
+                // The purchase associated to the link belongs to a different user and it cannot be redeemed.
+            }
+            is RedeemWebPurchaseListener.Result.Success -> {
+                val customerInfo: CustomerInfo = result.customerInfo
+                // Redemption was successful and entitlements were granted to the user.
+            }
+        }
+    }
+}

--- a/docs/web/web-billing/redemption-links.mdx
+++ b/docs/web/web-billing/redemption-links.mdx
@@ -46,8 +46,8 @@ The SDK versions supporting Redemption Links are:
 | purchases-flutter      | 8.4.0 and above                      |
 | purchases-unity        | 7.4.1 and above                      |
 | react-native-purchases | 8.5.0 and above                      |
-| purchases-kmp          | Coming soon                          |
-| purchases-capacitor    | Coming soon                          |
+| purchases-kmp          | 1.6.0+13.19.0 and above              |
+| purchases-capacitor    | 10.1.0 and above                     |
 
 In order to be able to redeem the redemption links in your mobile apps, follow these steps
 
@@ -170,6 +170,34 @@ import unityRedemption from "!!raw-loader!@site/code_blocks/web/web-billing/rede
 <RCCodeBlock
   tabs={[
     { type: "csharp", title: "Unity Redemption", content: unityRedemption },
+  ]}
+/>
+
+##### Kotlin Multiplatform
+
+In our Kotlin Multiplatform SDK, you will need to obtain the deep link first. There are several ways to do this, using a 3rd party library, or by writing the relevant android/iOS code in your app and passing the url back to the shared kotlin code.
+
+Once you have the deep link, you can use the following snippet to perform the redemption:
+
+import kmpRedemption from "!!raw-loader!@site/code_blocks/web/web-billing/redemption_kmp.kt";
+
+<RCCodeBlock
+  tabs={[
+    { type: "kotlin", title: "KMP Redemption", content: kmpRedemption },
+  ]}
+/>
+
+##### Capacitor
+
+In our Capacitor SDK, you will need to obtain the deep link first. Please read the official docs on how to parse deep links: https://capacitorjs.com/docs/guides/deep-links.
+
+Once you have the deep link, you can use the following snippet to perform the redemption:
+
+import capacitorRedemption from "!!raw-loader!@site/code_blocks/web/web-billing/redemption_capacitor.ts";
+
+<RCCodeBlock
+  tabs={[
+    { type: "typescript", title: "Capacitor Redemption", content: capacitorRedemption },
   ]}
 />
 


### PR DESCRIPTION
## Motivation / Description
We have just (are in the process of) releasing support for redemption links in KMP and Capacitor, the missing hybrids to support it. This updates the docs indicating this added support with some basic examples of API usage.
