### PR TITLE
Fix Web Billing renewal window

### DIFF
--- a/docs/web/web-billing/subscription-lifecycle.mdx
+++ b/docs/web/web-billing/subscription-lifecycle.mdx
@@ -34,7 +34,7 @@ The following trial eligibility can be set up per product. If a customer is elig
 
 ## Renewal
 
-RevenueCat will attempt to charge the payment method of a customer not more than 24 hours before the end of the current billing period, if the customer has not canceled their subscription. An invoice is generated for the renewal attempt.
+RevenueCat will attempt to charge the payment method of a customer not more than 1 hour before the end of the current billing period, if the customer has not canceled their subscription. An invoice is generated for the renewal attempt.
 
 ### Successful renewal
 


### PR DESCRIPTION
## Motivation / Description
Web Billing subscriptions are renewed up to 1 hour before the period ends, not 24 hours.

## Changes introduced

## Linear ticket (if any)

## Additional comments
