### PR TITLE
Clarified JWSTransactions StoreKit2 support in API v1 doc

### DIFF
--- a/openapi-spec/api-v1.yaml
+++ b/openapi-spec/api-v1.yaml
@@ -223,7 +223,7 @@ paths:
                 fetch_token:
                   type: string
                   description:
-                    For iOS, the base64 encoded receipt file, for Android
+                    For iOS, the base64 encoded receipt file (or JWSTransaction for StoreKit2), for Android
                     the receipt token, for Amazon the receipt, and for Stripe the
                     subscription ID or the Stripe Checkout Session ID.
                 product_id:


### PR DESCRIPTION

## Motivation / Description
A potential customer looking to migrate to RC reached out to ask whether our https://api.revenuecat.com/v1/receipts endpoint supports JWSTransactions from StoreKit2.
I think this could be clarified in the future by adding just an explicit mention in the API docs. Maybe something like this?
:arrow_right: For iOS, the base64-encoded receipt file (or JWSTransaction for StoreKit2); for Android, the receipt token; for Amazon, the receipt; and for Stripe, the subscription ID or the Stripe Checkout Session ID.

## Changes introduced

## Linear ticket (if any)

## Additional comments
