### PR TITLE
 Don't include beta versions in imgshield images

### DIFF
--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -13,7 +13,7 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ### Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
 

--- a/docs/getting-started/installation/capacitor.mdx
+++ b/docs/getting-started/installation/capacitor.mdx
@@ -11,7 +11,7 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-capacitor.svg?style=flat)](https://github.com/RevenueCat/purchases-capacitor/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-capacitor.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-capacitor/releases)
 
 import content from "!!raw-loader!@site/code_blocks/getting-started/installation/capacitor_add_plugin.shell";
 

--- a/docs/getting-started/installation/flutter.mdx
+++ b/docs/getting-started/installation/flutter.mdx
@@ -16,7 +16,7 @@ Minimum target: iOS 11.0+
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
 
 To use this plugin, add `purchases_flutter` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/) (and run an implicit dart pub get):
 

--- a/docs/getting-started/installation/ios.mdx
+++ b/docs/getting-started/installation/ios.mdx
@@ -11,7 +11,7 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
 
 RevenueCat for iOS can be installed either via [CocoaPods](/getting-started/installation/ios#section-install-via-cocoapods), [Carthage](ios#section-install-via-carthage), or [Swift Package Manager](/getting-started/installation/ios#section-install-via-swift-package-manager).
 

--- a/docs/getting-started/installation/kotlin-multiplatform.mdx
+++ b/docs/getting-started/installation/kotlin-multiplatform.mdx
@@ -20,7 +20,7 @@ iOS 13.0+
 
 Purchases for Kotlin Multiplatform (Google Play and iOS App Store) is available on Maven Central and can be included via Gradle.
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
 
 Add the following coordinates to your `libs.versions.toml`.
 

--- a/docs/getting-started/installation/reactnative.mdx
+++ b/docs/getting-started/installation/reactnative.mdx
@@ -11,7 +11,7 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
 
 Make sure that the deployment target for iOS is at least 13.4 and Android is at least 6.0 (API 23) [as defined here](https://github.com/facebook/react-native#-requirements).
 

--- a/docs/getting-started/installation/roku.mdx
+++ b/docs/getting-started/installation/roku.mdx
@@ -79,7 +79,7 @@ After you have configured the Roku Store app on RevenueCat, you should [create y
 
 ## Installing the SDK
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-roku.svg?style=flat)](https://github.com/RevenueCat/purchases-roku/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-roku.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-roku/releases)
 
 1. Clone the repository:
 

--- a/docs/getting-started/installation/web-sdk.mdx
+++ b/docs/getting-started/installation/web-sdk.mdx
@@ -13,7 +13,7 @@ With the RevenueCat Web SDK and our Web Billing (formerly RevenueCat Billing) en
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-js.svg?style=flat)](https://github.com/RevenueCat/purchases-js/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-js.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-js/releases)
 
 To install the RevenueCat Web SDK, add the `@revenuecat/purchases-js` package to your project using the package manager of your choice:
 

--- a/docs/test-and-launch/debugging.mdx
+++ b/docs/test-and-launch/debugging.mdx
@@ -103,7 +103,7 @@ Note: The debug UI won't compile for release builds, so you'll need to disable t
 
 In order to use the overlay, you need to include the debug view library which is available on Maven and can be included via Gradle. Currently, this is only available as a Jetpack Compose Composable.
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 import db12 from "!!raw-loader!@site/code_blocks/test-and-launch/debugging_13.groovy";
 import db13 from "!!raw-loader!@site/code_blocks/test-and-launch/debugging_14.kt";

--- a/docs/tools/customer-center/customer-center-flutter.mdx
+++ b/docs/tools/customer-center/customer-center-flutter.mdx
@@ -8,7 +8,7 @@ import { sdkVersions } from '@site/src/components/CustomerCenter/CustomerCenterS
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
 
 Before integrating the Customer Center in Flutter, add `purchases_ui_flutter` <code>{sdkVersions.flutter}</code> or higher in your `pubspec.yaml`:
 

--- a/docs/tools/customer-center/customer-center-integration-android.mdx
+++ b/docs/tools/customer-center/customer-center-integration-android.mdx
@@ -8,7 +8,7 @@ import { sdkVersions } from '@site/src/components/CustomerCenter/CustomerCenterS
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 Before integrating the Customer Center in Android, you need to add the `com.revenuecat.purchases:purchases-ui` SDK <code>{sdkVersions.android}</code> or higher to your app.
 

--- a/docs/tools/customer-center/customer-center-integration-ios.mdx
+++ b/docs/tools/customer-center/customer-center-integration-ios.mdx
@@ -9,7 +9,7 @@ import { sdkVersions } from '@site/src/components/CustomerCenter/CustomerCenterS
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
 
 Before integrating the Customer Center in iOS, you need to add the RevenueCatUI SDK <code>{sdkVersions.ios}</code> or higher to your app.
 

--- a/docs/tools/customer-center/customer-center-kmp.mdx
+++ b/docs/tools/customer-center/customer-center-kmp.mdx
@@ -13,7 +13,7 @@ import OverviewPartial from './_customer-center-installation-overview.mdx';
 
 CustomerCenter for Kotlin Multiplatform is available on Maven Central and can be included via Gradle starting at <code>{sdkVersions.kmp}</code>.
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
 
 Add the following Maven coordinates to your `libs.versions.toml`:
 ```toml libs.versions.toml

--- a/docs/tools/customer-center/customer-center-react-native.mdx
+++ b/docs/tools/customer-center/customer-center-react-native.mdx
@@ -8,7 +8,7 @@ import { sdkVersions } from '@site/src/components/CustomerCenter/CustomerCenterS
 
 ## Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
 
 Before integrating the Customer Center in React Native, update your `package.json` to include `react-native-purchases-ui` <code>{sdkVersions.reactNative}</code> or higher to your app.
 

--- a/docs/tools/paywalls-v2/installation.mdx
+++ b/docs/tools/paywalls-v2/installation.mdx
@@ -74,7 +74,7 @@ pod 'RevenueCatUI'
 
 ## Native Android Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 1. Add `RevenueCatUI`:
 ```groovy build.gradle
@@ -84,7 +84,7 @@ implementation 'com.revenuecat.purchases:purchases-ui:<latest version>'
 
 ## React Native Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
 
 - Update your `package.json` to include `react-native-purchases-ui`:
 ```json
@@ -98,7 +98,7 @@ implementation 'com.revenuecat.purchases:purchases-ui:<latest version>'
 
 ## Flutter Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
 
 - Add `purchases-ui-flutter` in your `pubspec.yaml`:
 ```yaml
@@ -110,7 +110,7 @@ dependencies:
 
 ## Kotlin Multiplatform Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
 
 Add the following Maven coordinates to your `libs.versions.toml`:
 ```toml libs.versions.toml

--- a/docs/tools/paywalls/installation.mdx
+++ b/docs/tools/paywalls/installation.mdx
@@ -28,7 +28,7 @@ Support for macOS, tvOS, and other platforms is coming soon!
 
 ## Native iOS Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
 
 ### Using SPM:
 
@@ -72,7 +72,7 @@ pod 'RevenueCatUI'
 
 ## Native Android Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 1. Add `RevenueCatUI`:
 ```groovy build.gradle
@@ -82,7 +82,7 @@ implementation 'com.revenuecat.purchases:purchases-ui:<latest version>'
 
 ## React Native Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
 
 - Update your `package.json` to include `react-native-purchases-ui`:
 ```json
@@ -96,7 +96,7 @@ implementation 'com.revenuecat.purchases:purchases-ui:<latest version>'
 
 ## Flutter Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
 
 - Add `purchases-ui-flutter` in your `pubspec.yaml`:
 ```yaml
@@ -108,7 +108,7 @@ dependencies:
 
 ## Kotlin Multiplatform Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-kmp.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-kmp/releases)
 
 Add the following Maven coordinates to your `libs.versions.toml`:
 ```toml libs.versions.toml


### PR DESCRIPTION
## Motivation / Description
We're preparing to release virtual currency beta SDKs for Android, and when they're released, these beta SDK versions will be the most recent versions. However, since they're betas, we don't want them appearing in all of our docs for everyone to install.

This PR adds a filter `filter=!*beta*` to all of our GitHub release imgshield images to ensure that we don't display any beta SDK versions as the latest stable version.

Documentation on the filter param can be found [here](https://shields.io/badges/git-hub-release).
