### PR TITLE
Change Flutter version to 8.6.0 as required version

### DIFF
--- a/src/components/CustomerCenter/CustomerCenterSDKTable.tsx
+++ b/src/components/CustomerCenter/CustomerCenterSDKTable.tsx
@@ -4,7 +4,7 @@ export const sdkVersions = {
   ios: "5.14.0",
   android: "8.12.2",
   reactNative: "8.6.0",
-  flutter: "8.7.0",
+  flutter: "8.6.0",
   kmp: "1.7.0",
 };
 

--- a/src/components/CustomerCenter/CustomerCenterSDKTable.tsx
+++ b/src/components/CustomerCenter/CustomerCenterSDKTable.tsx
@@ -3,7 +3,7 @@ import React from "react";
 export const sdkVersions = {
   ios: "5.14.0",
   android: "8.12.2",
-  reactNative: "8.6.0",
+  reactNative: "8.7.0",
   flutter: "8.6.0",
   kmp: "1.7.0",
 };


### PR DESCRIPTION
Minimum required version for Customer Center in Flutter is 8.6.0 not 8.7.0. 
Minimum required version for Customer Center in React Native is 8.7.0 not 8.6.0. 