### PR TITLE
Improve android installation docs by adding Kotlin code blocks

### DIFF
--- a/code_blocks/getting-started/installation/android_4.kts
+++ b/code_blocks/getting-started/installation/android_4.kts
@@ -1,0 +1,1 @@
+implementation("com.revenuecat.purchases:purchases:8.14.0")

--- a/code_blocks/getting-started/installation/android_4.kts
+++ b/code_blocks/getting-started/installation/android_4.kts
@@ -1,1 +1,1 @@
-implementation("com.revenuecat.purchases:purchases:8.14.0")
+implementation("com.revenuecat.purchases:purchases:8.15.1")

--- a/code_blocks/getting-started/installation/android_5.kt
+++ b/code_blocks/getting-started/installation/android_5.kt
@@ -1,0 +1,7 @@
+import com.revenuecat.purchases.CustomerInfo
+import com.revenuecat.purchases.Entitlement
+import com.revenuecat.purchases.Offering
+import com.revenuecat.purchases.Purchases
+import com.revenuecat.purchases.models.Period
+import com.revenuecat.purchases.models.Price
+import com.revenuecat.purchases.models.StoreProduct

--- a/code_blocks/getting-started/installation/android_6.kts
+++ b/code_blocks/getting-started/installation/android_6.kts
@@ -1,2 +1,2 @@
-implementation("com.revenuecat.purchases:purchases:8.14.0")
-implementation("com.revenuecat.purchases:purchases-store-amazon:8.14.0")
+implementation("com.revenuecat.purchases:purchases:8.15.1")
+implementation("com.revenuecat.purchases:purchases-store-amazon:8.15.1")

--- a/code_blocks/getting-started/installation/android_6.kts
+++ b/code_blocks/getting-started/installation/android_6.kts
@@ -1,0 +1,2 @@
+implementation("com.revenuecat.purchases:purchases:8.14.0")
+implementation("com.revenuecat.purchases:purchases-store-amazon:8.14.0")

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -17,17 +17,29 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
 
-import content from "!!raw-loader!@site/code_blocks/getting-started/installation/android_1.groovy";
+import buildGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_4.kts";
+import buildGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_1.groovy";
 
-<RCCodeBlock tabs={[{ type: "groovy", content: content, name: "Groovy" }]} />
+<RCCodeBlock
+  tabs={[
+      { type: "kotlin", content: buildGradle1, name: "kts" },
+      { type: "groovy", content: buildGradle2, name: "groovy" },
+    ]}
+/>
 
 ### Import Purchases
 
 You should now be able to import `Purchases`.
 
+import kotlinContent from "!!raw-loader!@site/code_blocks/getting-started/installation/android_5.kt";
 import javaContent from "!!raw-loader!@site/code_blocks/getting-started/installation/android_2.java";
 
-<RCCodeBlock tabs={[{ type: "java", content: javaContent, name: "Java" }]} />
+<RCCodeBlock
+  tabs={[
+      { type: "kotlin", content: kotlinContent, name: "kotlin" },
+      { type: "java", content: javaContent, name: "java" },
+    ]}
+/>
 
 ### Configure Proguard (Optional)
 
@@ -63,10 +75,14 @@ You can find Android's documentation on the various `launchMode` options [here](
 
 Add a new dependency to the build.gradle apart from the regular `purchases` dependency. These new dependencies have the classes needed to use Amazon IAP:
 
-import unityContent from "!!raw-loader!@site/code_blocks/getting-started/installation/android_3.groovy";
+import amazonGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_6.kts";
+import amazonGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_3.groovy";
 
 <RCCodeBlock
-  tabs={[{ type: "groovy", content: unityContent, name: "Groovy" }]}
+  tabs={[
+      { type: "kotlin", content: amazonGradle1, name: "kts" },
+      { type: "groovy", content: amazonGradle2, name: "groovy" },
+    ]}
 />
 
 ### Add Amazon public key

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -17,7 +17,7 @@ Purchases for Android (Google Play and Amazon Appstore) is available on Maven an
 
 You can find the latest version below, and for more details, visit the [Releases page](https://github.com/RevenueCat/purchases-android/releases).
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/v/release/RevenueCat/purchases-android.svg?&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 import buildGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_4.kts";
 import buildGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_1.groovy";
@@ -79,7 +79,7 @@ Add a new dependency to the `build.gradle` apart from the regular `purchases` de
 
 You can find the latest version below, and for more details, visit the [Releases page](https://github.com/RevenueCat/purchases-android/releases).
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
+[![Release](https://img.shields.io/github/v/release/RevenueCat/purchases-android.svg?&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 import amazonGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_6.kts";
 import amazonGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_3.groovy";

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -13,17 +13,19 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 ### Installation
 
-[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
-
 Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
+
+You can check out the latest version indicated below. Also, you can check the https://github.com/RevenueCat/purchases-android/releases.
+
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 import buildGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_4.kts";
 import buildGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_1.groovy";
 
 <RCCodeBlock
   tabs={[
-      { type: "kotlin", content: buildGradle1, name: "kts" },
-      { type: "groovy", content: buildGradle2, name: "groovy" },
+      { type: "kotlin", content: buildGradle1, name: "Kotlin" },
+      { type: "groovy", content: buildGradle2, name: "Groovy" },
     ]}
 />
 
@@ -36,8 +38,8 @@ import javaContent from "!!raw-loader!@site/code_blocks/getting-started/installa
 
 <RCCodeBlock
   tabs={[
-      { type: "kotlin", content: kotlinContent, name: "kotlin" },
-      { type: "java", content: javaContent, name: "java" },
+      { type: "kotlin", content: kotlinContent, name: "Kotlin" },
+      { type: "java", content: javaContent, name: "Java" },
     ]}
 />
 
@@ -80,8 +82,8 @@ import amazonGradle2 from "!!raw-loader!@site/code_blocks/getting-started/instal
 
 <RCCodeBlock
   tabs={[
-      { type: "kotlin", content: amazonGradle1, name: "kts" },
-      { type: "groovy", content: amazonGradle2, name: "groovy" },
+      { type: "kotlin", content: amazonGradle1, name: "Kotlin" },
+      { type: "groovy", content: amazonGradle2, name: "Groovy" },
     ]}
 />
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -15,7 +15,7 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 Purchases for Android (Google Play and Amazon Appstore) is available on Maven and can be included via Gradle.
 
-You can check out the latest version indicated below. Also, you can check the https://github.com/RevenueCat/purchases-android/releases.
+You can find the latest version below, and for more details, visit the [Releases page](https://github.com/RevenueCat/purchases-android/releases).
 
 [![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
@@ -75,7 +75,11 @@ You can find Android's documentation on the various `launchMode` options [here](
 
 ### Additional Dependencies
 
-Add a new dependency to the build.gradle apart from the regular `purchases` dependency. These new dependencies have the classes needed to use Amazon IAP:
+Add a new dependency to the `build.gradle` apart from the regular `purchases` dependency. These new dependencies have the classes needed to use Amazon IAP:
+
+You can find the latest version below, and for more details, visit the [Releases page](https://github.com/RevenueCat/purchases-android/releases).
+
+[![Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=!*beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 import amazonGradle1 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_6.kts";
 import amazonGradle2 from "!!raw-loader!@site/code_blocks/getting-started/installation/android_3.groovy";


### PR DESCRIPTION
## Motivation / Description

Improve the Android installation documentation by adding Kotlin code blocks. Since Google has announced Kotlin-first support for Android, most Android developers now use Kotlin as the default language—so including Kotlin snippets would better align with current development practices and benefit the majority of users.