### PR TITLE
Hybrid VC instructions

### DIFF
--- a/code_blocks/virtual-currency/vc-balance-sdk-flutter.dart
+++ b/code_blocks/virtual-currency/vc-balance-sdk-flutter.dart
@@ -1,0 +1,11 @@
+// Get the balance of a specific virtual currency
+int balance = customerInfo.virtualCurrencies[<your_virtual_currency_code>]?.balance;
+
+// Iterate through all virtual currency balances
+for (String virtualCurrencyCode in customerInfo.virtualCurrencies.keys) {
+  VirtualCurrencyInfo? virtualCurrencyInfo = customerInfo.virtualCurrencies[virtualCurrencyCode];
+  if (virtualCurrencyInfo != null) {
+    int balance = virtualCurrencyInfo.balance;
+    print("$virtualCurrencyCode: $balance");
+  }
+}

--- a/code_blocks/virtual-currency/vc-balance-sdk-react-native.ts
+++ b/code_blocks/virtual-currency/vc-balance-sdk-react-native.ts
@@ -1,0 +1,8 @@
+// Get the balance of a specific virtual currency
+const balance = customerInfo.virtualCurrencies[<your_virtual_currency_code>]?.balance;
+
+// Iterate through all virtual currency balances
+for (const virtualCurrencyCode of Object.keys(customerInfo.virtualCurrencies)) {
+  const balance = customerInfo.virtualCurrencies[virtualCurrencyCode]?.balance;
+  console.log(`${virtualCurrencyCode}: ${balance}`);
+}

--- a/docs/offerings/virtual-currency.mdx
+++ b/docs/offerings/virtual-currency.mdx
@@ -223,7 +223,7 @@ import fetchVCBalancesFlutter from "!!raw-loader!@site/code_blocks/virtual-curre
       name: "Kotlin",
     },
     {
-      type: "typescript",
+      type: "rn",
       content: fetchVCBalancesReactNative,
       name: "React Native",
     },

--- a/docs/offerings/virtual-currency.mdx
+++ b/docs/offerings/virtual-currency.mdx
@@ -56,6 +56,10 @@ Use the `virtual-currency-beta` branch of the purchases-ios SDK to access the vi
 
 ![](/images/virtual-currency/ios-spm-virtual-currency-beta-branch-configuration.png)
 
+If you're using CocoaPods, set your `purchases-ios` version to the most recent `vc-beta` version in your Podfile:
+
+[![Latest Virtual Currency iOS Beta Release](https://img.shields.io/github/release/RevenueCat/purchases-ios.svg?filter=*vc-beta*&style=flat)](https://github.com/RevenueCat/purchases-ios/releases)
+
 ### Android
 
 When adding the purchases-android SDK to your app, use the most recent `vc-beta` version when adding `purchases-android` to your `build.gradle`:
@@ -63,6 +67,8 @@ When adding the purchases-android SDK to your app, use the most recent `vc-beta`
 [![Latest Virtual Currency Android Beta Release](https://img.shields.io/github/release/RevenueCat/purchases-android.svg?filter=*vc-beta*&style=flat)](https://github.com/RevenueCat/purchases-android/releases)
 
 ```kotlin
+// build.gradle
+
 implementation 'com.revenuecat.purchases:purchases:8.14.2-vc-beta.1'
 ```
 
@@ -78,6 +84,31 @@ import androidExperimentalAPIAnnotationExample from "!!raw-loader!@site/code_blo
     },
   ]}
 />
+
+### React Native
+When installing the purchases SDK in your app, use the latest virtual currencies beta version:
+
+[![Latest Virtual Currency React Native Beta Release](https://img.shields.io/github/release/RevenueCat/react-native-purchases.svg?filter=*vc-beta*&style=flat)](https://github.com/RevenueCat/react-native-purchases/releases)
+
+```json
+// Package.json
+
+"dependencies": {
+  "react-native-purchases": "8.9.1-vc-beta.1",
+}
+```
+
+### Flutter
+When installing the purchases SDK in your app, use the latest virtual currencies beta version in your `pubspec.yaml` file:
+
+[![Latest Virtual Currency Flutter Beta Release](https://img.shields.io/github/release/RevenueCat/purchases-flutter.svg?filter=*vc-beta*&style=flat)](https://github.com/RevenueCat/purchases-flutter/releases)
+
+```yaml
+# pubspec.yaml
+
+dependencies:
+  purchases_flutter: '8.7.0-vc-beta.1'
+```
 
 ## Usage
 
@@ -176,6 +207,8 @@ If you're using the virtual currency SDK betas, you can fetch the virtual curren
 
 import fetchVCBalancesSwift from "!!raw-loader!@site/code_blocks/virtual-currency/vc-balance-sdk-ios.swift";
 import fetchVCBalancesKotlin from "!!raw-loader!@site/code_blocks/virtual-currency/vc-balance-sdk-android.kt";
+import fetchVCBalancesReactNative from "!!raw-loader!@site/code_blocks/virtual-currency/vc-balance-sdk-react-native.ts";
+import fetchVCBalancesFlutter from "!!raw-loader!@site/code_blocks/virtual-currency/vc-balance-sdk-flutter.dart";
 
 <RCCodeBlock
   tabs={[
@@ -188,6 +221,16 @@ import fetchVCBalancesKotlin from "!!raw-loader!@site/code_blocks/virtual-curren
       type: "kotlin",
       content: fetchVCBalancesKotlin,
       name: "Kotlin",
+    },
+    {
+      type: "typescript",
+      content: fetchVCBalancesReactNative,
+      name: "React Native",
+    },
+    {
+      type: "flutter",
+      content: fetchVCBalancesFlutter,
+      name: "Flutter",
     },
   ]}
 />


### PR DESCRIPTION
This PR introduces instructions for installing and using the virtual currency betas in React Native and Flutter.

It also makes a few minor tweaks to the native installation instructions.