### PR TITLE
Use hooks for RN code snippets

### DIFF
--- a/code_blocks/getting-started/configuring-sdk_6.js
+++ b/code_blocks/getting-started/configuring-sdk_6.js
@@ -1,10 +1,11 @@
-import { Platform } from 'react-native';
+import { Platform, useEffect } from 'react-native';
+import Purchases from 'react-native-purchases';
 
 //...
 
-export default class App extends React.Component {
+export default function App() {
 
-  componentDidMount() {
+  useEffect(() => {
     Purchases.setLogLevel(Purchases.LOG_LEVEL.DEBUG);
 
     if (Platform.OS === 'ios') {
@@ -16,5 +17,5 @@ export default class App extends React.Component {
     	Purchases.configure({ apiKey: <public_amazon_api_key>, useAmazon: true });
     }
 
-  }
+  }, []);
 }

--- a/code_blocks/getting-started/draft-quickstart_6.js
+++ b/code_blocks/getting-started/draft-quickstart_6.js
@@ -1,8 +1,11 @@
-export default class App extends React.Component {
+import { useEffect } from 'react-native';
+import Purchases from 'react-native-purchases';
+
+export default function App() {
   
-  componentDidMount() {
+  useEffect(() => {
     Purchases.setDebugLogsEnabled(true);
     Purchases.setup("public_sdk_key");
-  }
+  }, []);
   
 }

--- a/code_blocks/getting-started/getting-started-old_6.ts
+++ b/code_blocks/getting-started/getting-started-old_6.ts
@@ -1,10 +1,11 @@
-import { Platform } from 'react-native';
+import { Platform, useEffect } from 'react-native';
+import Purchases from 'react-native-purchases';
 
 //...
 
-export default class App extends React.Component {
+export default function App() {
  
-  componentDidMount() {
+  useEffect(() => {
     Purchases.setDebugLogsEnabled(true);
     
     if (Platform.OS === 'ios') {
@@ -16,5 +17,5 @@ export default class App extends React.Component {
         await Purchases.configure({ apiKey: "public_amazon_sdk_key", useAmazon: true });
     }
     
-  }
+  }, []);
 }

--- a/code_blocks/getting-started/getting-started_6.ts
+++ b/code_blocks/getting-started/getting-started_6.ts
@@ -1,10 +1,11 @@
-import { Platform } from 'react-native';
+import { Platform, useEffect } from 'react-native';
+import Purchases from 'react-native-purchases';
 
 //...
 
-export default class App extends React.Component {
+export default function App() {
 
-  componentDidMount() {
+  useEffect(() => {
     Purchases.setLogLevel(LOG_LEVEL.VERBOSE);
 
     if (Platform.OS === 'ios') {
@@ -16,5 +17,5 @@ export default class App extends React.Component {
        Purchases.configure({ apiKey: <revenuecat_project_amazon_api_key>, useAmazon: true });
     }
 
-  }
+  }, []);
 }


### PR DESCRIPTION
## Motivation / Description

I realized we were still using `componentDidMount` for RN code snippets, which hasn't been best practice in more than 5 years! (Hooks were introduced in React 16.8 in February 2019, and became the de facto standard by early 2020). 

## Changes introduced

## Linear ticket (if any)

## Additional comments
