### PR TITLE
Correct "subscriptipon" to "subscription"

### DIFF
--- a/code_blocks/integrations/scheduled-data-exports_11.pgsql
+++ b/code_blocks/integrations/scheduled-data-exports_11.pgsql
@@ -2,7 +2,7 @@
 
 WITH
 
-filtered_subscriptipon_transactions AS (
+filtered_subscription_transactions AS (
     SELECT
         *,
         CASE WHEN effective_end_time IS NOT NULL THEN
@@ -78,14 +78,14 @@ actives AS (
         END
     ) AS renewal_mrr
     
-  FROM filtered_subscriptipon_transactions
+  FROM filtered_subscription_transactions
   GROUP BY 1),
   
 expirations AS (
   SELECT
     DATE(effective_end_time) AS date,
     SUM(transaction_mrr) AS expired_mrr
-  FROM filtered_subscriptipon_transactions
+  FROM filtered_subscription_transactions
   GROUP BY 1)
 
 SELECT


### PR DESCRIPTION
Just cleaning up a typo to look nicer, no functional changes

## Motivation / Description
MRR SDE Example Query had a typo in the subtable name, fixing this just to look nicer

## Changes introduced
`filtered_subscriptipon_transactions` => `filtered_subscription_transactions`

## Linear ticket (if any)

## Additional comments
