### PR TITLE
Update google-play-checklists.mdx

### DIFF
--- a/docs/service-credentials/creating-play-service-credentials/google-play-checklists.mdx
+++ b/docs/service-credentials/creating-play-service-credentials/google-play-checklists.mdx
@@ -110,6 +110,13 @@ Note that while our [credentials guide](/service-credentials/creating-play-servi
   <input type="checkbox" />I have enabled the Pub/Sub API for the same project
   in which I previously created service credentials
 </label>
+<label class="google-checkbox">
+  <input type="checkbox" />I have added "google-play-developer-notifications@system.gserviceaccount.com" service account
+as Pub/Sub Publisher for created Topic (this must be entered manually as this service account is not visible in console)
+</label>
+<label class="google-checkbox">
+  <input type="checkbox" />I have added my created service account as Pub/Sub Subscriber for created Topic
+</label>
 
 ### In RevenueCat:
 


### PR DESCRIPTION
Extend Google Real-Time Developer Notifications Checklist

## Motivation / Description

I encountered this problem when enabling Google Real-Time Developer Notifications. I did not find a word about it in the documentation.

## Changes introduced

Add two checks for google play checklist

## Linear ticket (if any)

## Additional comments

Revenue cat receives notifications from google console `Pub/Sub Topic` as a `Pub/Sub Subscriber`. To enable google play console to send notifications to `Pub/Sub Topic` `google-play-developer-notifications@system.gserviceaccount.com` must have `Pub/Sub Publisher` role for given `Pub/Sub Topic`. This service account is not visible to google console users. That is why it has to be added manually. Also, revenue cat service account must have `Pub/Sub Subscriber` role for the same `Pub/Sub Topic` to be able to receive notifications.
