### PR TITLE
clarify Apple S2S handling and mention forwarding to custom URL

### DIFF
--- a/docs/platform-resources/server-notifications/apple-server-notifications.mdx
+++ b/docs/platform-resources/server-notifications/apple-server-notifications.mdx
@@ -130,5 +130,5 @@ If you want to also receive these notifications on your own server for one or bo
 
 :::tip Apple S2S notifications update subscriptions for existing users
 
-If RevenueCat receives a notification for a user that doesn't have any purchases in RevenueCat, a 200 code will be sent and the request will be ignored, so the last received notification timestamp won't be updated. Keep this in mind when forwarding events yourself.
+If RevenueCat receives a notification for a user that doesn't have any purchases in RevenueCat, a 200 status code will be returned and the request will be ignored, meaning the last received notification timestamp won't be updated. Keep this in mind when forwarding events yourself. However, if you've defined an **Apple Server Notification Forwarding URL**, the notification will still be forwarded to that endpoint.
 :::


### PR DESCRIPTION
## Motivation / Description

Clarified how RevenueCat handles Apple Server-to-Server (S2S) notifications for a user that doesn't have any purchases. Previously, it wasn't clear that the notification would still be forwarded if a custom Apple Server Notification Forwarding URL was configured.

## Changes introduced

- Updated tip in the documentation to mention that S2S notifications are forwarded to the Apple Server Notification Forwarding URL, even if the user has no associated purchases in RevenueCat.

## Linear ticket (if any)

N/A

## Additional comments

N/A