### PR TITLE
Add data processing time section to migration docs

### DIFF
--- a/docs/migrating-to-revenuecat/migrating-existing-subscriptions.mdx
+++ b/docs/migrating-to-revenuecat/migrating-existing-subscriptions.mdx
@@ -51,3 +51,12 @@ When a customer launches with the first version containing RevenueCat it will tr
 :::warning Do not sync or restore on every app launch
 It's okay to trigger a sync once per subscriber programmatically the first time they open a version of your app containing RevenueCat. You **should not** call this programmatically on every app launch for every user. This can increase latency in your app and can unintentionally alias customers together.
 :::
+
+### Data Processing Time
+
+After importing purchase data into RevenueCat (whether via server-side or client-side methods), please note that there may be a delay before this data is fully reflected across all RevenueCat systems:
+
+- **Customer Lists**: It may take several hours for newly imported customers to appear in your Customer Lists.
+- **Charts and Analytics**: Charts and analytics data typically update within 24 hours, but larger imports may take longer to fully process.
+
+During this processing period, you can still access individual customer information through the Customer Profile View or API even if aggregate data is still being updated.


### PR DESCRIPTION
Motivation / Description
There was a need to add clear expectations about data processing times for customers migrating to RevenueCat. Users were confused about why their imported purchase data wasn't immediately appearing in the dashboard, leading to support tickets and confusion during migration.

Changes introduced
Added a new "Data Processing Time" section to the migration documentation
Included specific timeframes for Customer Lists updates (several hours)
Included specific timeframes for Charts and Analytics updates (24 hours+)
Added clarification that individual customer data is still accessible during processing

Linear ticket (if any)

Additional comments