### PR TITLE
fix: Use latest flutter version reference docs

### DIFF
--- a/docs/platform-resources/sdk-reference.mdx
+++ b/docs/platform-resources/sdk-reference.mdx
@@ -14,7 +14,7 @@ The API reference documentation provides detailed information for each of the cl
 
 [Android Reference →](https://sdk.revenuecat.com/android/index.html)
 
-[Flutter Reference →](https://pub.dev/documentation/purchases_flutter/6.5.0/)
+[Flutter Reference →](https://pub.dev/documentation/purchases_flutter/latest/)
 
 [React Native Reference →](https://revenuecat.github.io/react-native-purchases-docs)
 


### PR DESCRIPTION
## Motivation / Description
We were pointing to a pretty old version of the flutter reference docs. This updates the link to use the latest.

## Changes introduced

## Linear ticket (if any)

## Additional comments
