### PR TITLE
ShowCustomerCenter version notice for Android

### DIFF
--- a/docs/tools/customer-center/customer-center-integration-android.mdx
+++ b/docs/tools/customer-center/customer-center-integration-android.mdx
@@ -28,7 +28,7 @@ import usageViewKotlin from "!!raw-loader!@site/code_blocks/tools/customer-cente
   ]}
 />
 
-Alternatively, you can instantiate the Customer Center as an Activity:
+Alternatively, you can instantiate the Customer Center as an Activity in `com.revenuecat.purchases:purchases-ui` SDK <code>8.13.0</code> or higher:
 
 import usageActivityKotlin from "!!raw-loader!@site/code_blocks/tools/customer-center-usage-2.kt";
 


### PR DESCRIPTION
## Motivation / Description

Customer Center was made available on Android in com.revenuecat.purchases:purchases-ui 8.12.2 and higher. However, our docs reference instantiating the Customer Center as an Activity, which is only available in 8.13.0 and higher.

## Changes introduced

## Linear ticket (if any)

## Additional comments

This caused confusion for a customer in this ticket:
https://revenuecat.zendesk.com/agent/tickets/57242
