### PR TITLE
Adds a section to the Web Billing docs related to the April 2025 IAP ruling against Apple

### DIFF
--- a/docs/tools/paywalls-v2/change-log.mdx
+++ b/docs/tools/paywalls-v2/change-log.mdx
@@ -8,6 +8,7 @@ Notable releases & fixes related to Paywalls v2.
 
 | Date | Description |
 | :----------------- | :---------- |
+| May 1, 2025 | iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1: Added support for Web Paywalls as a button destination. |
 | April 4, 2025 | Localizations can now be exported and re-imported to update localizations through your existing workflows. |
 | April 4, 2025 | Variables now support case modifiers for `uppercase`, `lowercase`, and `capitalize`. [Learn more](https://www.revenuecat.com/docs/tools/paywalls-v2/creating-paywalls/variables#variable-modifiers) |
 | April 3, 2025 | Added the carousel component. Update to the latest SDK versions to get all fixes and improvements related to this component. [Learn more](https://www.revenuecat.com/docs/tools/paywalls-v2/creating-paywalls/components#carousel-component)|

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -211,7 +211,7 @@ You can choose from the following actions:
 **Navigate to** additionally supports navigating to your Privacy Policy, Terms of Service, or any other custom URL of your choosing. URLs can be opened via In-App Browser, External Browser, or Deep Link.
 
 :::info Web Paywalls
-Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchaeses.[Learn more about Web Paywalls](/docs/web-paywalls).
+Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchaeses.[Learn more about Web Paywalls](https://www.revenuecat.com/blog/).
 :::
 
 ## Footer

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -210,6 +210,10 @@ You can choose from the following actions:
 
 **Navigate to** additionally supports navigating to your Privacy Policy, Terms of Service, or any other custom URL of your choosing. URLs can be opened via In-App Browser, External Browser, or Deep Link.
 
+:::info Web Paywalls
+Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchaeses.[Learn more about Web Paywalls](/docs/web-paywalls).
+:::
+
 ## Footer
 
 If you'd like to have a fixed footer at the bottom of your paywall, you can add one using the footer component. This is especially important if you want to add optional content to your paywall that a customer may want to explore if they're interested, but don't necessarily want things like the purchase button buried beneath that content.

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -211,7 +211,7 @@ You can choose from the following actions:
 **Navigate to** additionally supports navigating to your Privacy Policy, Terms of Service, or any other custom URL of your choosing. URLs can be opened via In-App Browser, External Browser, or Deep Link.
 
 :::info Web Paywalls
-Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchaeses.[Learn more about Web Paywalls](https://www.revenuecat.com/blog/).
+Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchases.[Learn more about Web Paywalls](https://www.revenuecat.com/blog/).
 :::
 
 ## Footer

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -211,7 +211,7 @@ You can choose from the following actions:
 **Navigate to** additionally supports navigating to your Privacy Policy, Terms of Service, or any other custom URL of your choosing. URLs can be opened via In-App Browser, External Browser, or Deep Link.
 
 :::info Web Paywalls
-Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchases.[Learn more about Web Paywalls](https://www.revenuecat.com/blog/).
+Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchases.[Learn more about Web Paywalls](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons).
 :::
 
 ## Footer

--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -17,7 +17,7 @@ This enables use cases such as:
 - Offering a unified experience for your app across mobile and web, with the same set of entitlements
 
 :::info April 2025 U.S. District Court Ruling on External Payment Options
-A recent U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. As a result, iOS developers are now permitted to guide users to web-based payment flows without additional Apple fees or restrictive design requirements. You can [find more details on the RevenueCat blog](https://www.revenuecat.com/blog/).
+A recent U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. As a result, iOS developers are now permitted to guide users to web-based payment flows without additional Apple fees or restrictive design requirements. You can [find more details on the RevenueCat blog](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons).
 :::
 
 ## Web Billing integration paths

--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -16,6 +16,10 @@ This enables use cases such as:
 - Collecting web payments from an existing audience, without the need to install the app first or create an account
 - Offering a unified experience for your app across mobile and web, with the same set of entitlements
 
+:::info April 2025 U.S. District Court Ruling on External Payment Options
+A recent U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. As a result, iOS developers are now permitted to guide users to web-based payment flows without additional Apple fees or restrictive design requirements. You can [find more details on the RevenueCat blog](https://www.revenuecat.com/blog/).
+:::
+
 ## Web Billing integration paths
 
 #### Web SDK


### PR DESCRIPTION
## Motivation / Description
This ruling is big news for IAP and RevenueCat.

## Changes introduced
- Adds sections to the Web Billing and Creating Paywalls docs related to the April 2025 IAP ruling against Apple
- Updates Paywalls-v2 change log to include Web Paywall as button destination.

