### PR TITLE
Add FAQ for web payments

### DIFF
--- a/docs/web/faq.mdx
+++ b/docs/web/faq.mdx
@@ -32,3 +32,11 @@ Add a new app in your RevenueCat project and select **Web Billing** as the payme
 ### What does this mean for web payments outside of the United States?
 
 This ruling only affects web payments in the United States. The App Store has existing restrictions on web payments outside of the United States.
+
+### Can I use my existing web checkout with Paywalls v2?
+
+Not yet, we are working on adding support for existing web checkouts with Paywalls v2.
+
+### Can I send a customer directly to the checkout flow for a given product?
+
+Yes, but only if your offering has a single product. We are working on adding support for linking to a specific product in an offering.

--- a/docs/web/faq.mdx
+++ b/docs/web/faq.mdx
@@ -1,0 +1,34 @@
+---
+title: Frequently Asked Questions
+slug: faqs
+sidebar_label: FAQs
+---
+
+In late April 2025, a U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like [Web Billing](/web/web-billing/overview).
+
+As a result, iOS developers are now permitted to guide users to web-based payment flows without additional Apple fees or restrictive design requirements.
+
+## RevenueCat Web Billing
+
+RevenueCat's existing Web Billing solution allows you to easily start selling subscriptions and one-time purchases on the web, and connect them with the same subscriptions and entitlements on mobile. Web Billing is also compatible with [Paywalls v2](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/).
+
+Get started with Web Billing by following the [setup guide](/web/web-billing/overview).
+
+## Recent Updates
+
+Notable updates to external web payments and RevenueCat Web Billing.
+
+| Date           | Description                                                                                                                                                                                                                                                                                             |
+| :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| May 1, 2025    | Added support for Web Paywalls as a button destination in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Paywall Buttons.                                             |
+| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling. |
+
+## FAQs
+
+### How do I add web payments to my iOS app?
+
+Add a new app in your RevenueCat project and select **Web Billing** as the payment provider. Read more in [Configuring Web Billing](/web/web-billing/product-setup).
+
+### What does this mean for web payments outside of the United States?
+
+This ruling only affects web payments in the United States. The App Store has existing restrictions on web payments outside of the United States.

--- a/sidebars.js
+++ b/sidebars.js
@@ -207,6 +207,7 @@ const webSDKCategory = Category({
       itemsPathPrefix: "integrations/",
       items: [Page({ slug: "stripe" }), Page({ slug: "paddle" })],
     }),
+    Page({ slug: "faq" }),
   ],
 });
 


### PR DESCRIPTION
## Motivation / Description

Support's getting a lot of questions about external web payments with the recent ruling, need somewhere to hold context

## Changes introduced

- Adds a new FAQ for web-related changes, including a changelog

## Linear ticket (if any)

## Additional comments
