### PR TITLE
Add an explicit Web Purchase Button page

### DIFF
--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -198,6 +198,14 @@ The purchase button is tied to your packages, and is how a customer begins the p
 
 It's shape can be configured as a pill, or a rectangle with a configurable border radius; and as a parent component it can also contain other components within it, which you might use to show multiple lines of text, an icon, etc.
 
+### Web Paywall Button
+
+To add an external link to a Web Paywall within your paywall, you can use a Web Paywall Button. Learn more about the Web Paywall Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
+
+:::info Supported SDKs
+The Web Paywall Button is currently supported in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1 and up.
+:::
+
 ## Button
 
 For all other buttons you may wish to add on your paywall, you can use the button component. The key difference between a button and other stacks is that it has configurable **Actions**.
@@ -209,10 +217,6 @@ You can choose from the following actions:
 3. Navigate to
 
 **Navigate to** additionally supports navigating to your Privacy Policy, Terms of Service, or any other custom URL of your choosing. URLs can be opened via In-App Browser, External Browser, or Deep Link.
-
-:::info Web Paywalls
-Our latest iOS SDK versions also support Web Paywalls as a button destination, so you can offer your customers an alternative to in-app purchases.[Learn more about Web Paywalls](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons).
-:::
 
 ## Footer
 

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -198,12 +198,12 @@ The purchase button is tied to your packages, and is how a customer begins the p
 
 It's shape can be configured as a pill, or a rectangle with a configurable border radius; and as a parent component it can also contain other components within it, which you might use to show multiple lines of text, an icon, etc.
 
-### Web Paywall Button
+### Web Purchase Button
 
-To add an external link to a Web Paywall within your paywall in supported countries, you can use a Web Paywall Button. Learn more about the Web Paywall Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
+To add an external link to a Web Paywall within your paywall in supported countries, you can use a Web Purchase Button. Learn more about the Web Purchase Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
 
 :::info Supported SDKs
-The Web Paywall Button is currently supported in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1 and up.
+The Web Purchase Button is currently supported in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1 and up.
 :::
 
 ## Button

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -200,7 +200,7 @@ It's shape can be configured as a pill, or a rectangle with a configurable borde
 
 ### Web Paywall Button
 
-To add an external link to a Web Paywall within your paywall, you can use a Web Paywall Button. Learn more about the Web Paywall Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
+To add an external link to a Web Paywall within your paywall in supported countries, you can use a Web Paywall Button. Learn more about the Web Paywall Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
 
 :::info Supported SDKs
 The Web Paywall Button is currently supported in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1 and up.

--- a/docs/tools/paywalls-v2/creating-paywalls/components.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/components.mdx
@@ -200,7 +200,7 @@ It's shape can be configured as a pill, or a rectangle with a configurable borde
 
 ### Web Purchase Button
 
-To add an external link to a Web Paywall within your paywall in supported countries, you can use a Web Purchase Button. Learn more about the Web Purchase Button [here](/tools/paywalls-v2/creating-paywalls/web-paywall-button).
+To add an external link to a Web Paywall within your paywall in supported countries, you can use a Web Purchase Button. Learn more about the Web Purchase Button [here](/tools/paywalls-v2/creating-paywalls/web-purchase-button).
 
 :::info Supported SDKs
 The Web Purchase Button is currently supported in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1 and up.

--- a/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
@@ -12,6 +12,8 @@ RevenueCat Paywalls v2 supports the Web Paywall Button as a button destination a
 
 To add a Web Paywall Button to your paywall, you can use the Web Paywall Button component.
 
+<YouTubeEmbed videoId="XF9cbvyiK48" title="Web Paywall Button" />
+
 ## Supported SDK versions
 
 | RevenueCat SDK           | Version required for Web Paywall Button | 

--- a/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
@@ -8,7 +8,7 @@ sidebar_label: Web Paywall Button
 Read more about the new Web Paywall Button in our [blog post](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons) announcement.
 :::
 
-RevenueCat Paywalls v2 supports the Web Paywall Button as a button destination as an alternative to the default in-app purchase button. The Web Paywall Buttons opens an external link from your app to a Web Billing paywall.
+RevenueCat Paywalls v2 supports the Web Paywall Button as a button destination as an alternative to the default purchase button. The Web Paywall Buttons opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.
 
 To add a Web Paywall Button to your paywall, you can use the Web Paywall Button component.
 
@@ -24,4 +24,4 @@ To add a Web Paywall Button to your paywall, you can use the Web Paywall Button 
 
 ## Considerations
 
-For more information about external web purchase support for each platform, see [FAQs](/web/faqs).
+For more information about support for external web purchases, see [FAQs](/web/faqs).

--- a/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-paywall-button.mdx
@@ -1,0 +1,27 @@
+---
+title: Web Paywall Button
+slug: web-paywall-button
+sidebar_label: Web Paywall Button
+---
+
+:::info Introduction
+Read more about the new Web Paywall Button in our [blog post](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons) announcement.
+:::
+
+RevenueCat Paywalls v2 supports the Web Paywall Button as a button destination as an alternative to the default in-app purchase button. The Web Paywall Buttons opens an external link from your app to a Web Billing paywall.
+
+To add a Web Paywall Button to your paywall, you can use the Web Paywall Button component.
+
+## Supported SDK versions
+
+| RevenueCat SDK           | Version required for Web Paywall Button | 
+| :----------------------- | :--------------------------------------------- |
+| purchases-ios             | 5.22.2 and up                 |
+| react-native-purchases | 8.9.6 and up                 | 
+| purchases-flutter         | 8.7.5 and up                 |
+| purchases-kmp             | 1.7.7+13.29.1 and up                  |
+| Other SDKs         | Not supported                  |
+
+## Considerations
+
+For more information about external web purchase support for each platform, see [FAQs](/web/faqs).

--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -10,7 +10,7 @@ Read more about the new Web Purchase Button in our [blog post](https://revenueca
 
 RevenueCat Paywalls v2 supports the Web Purchase Button as a button destination as an alternative to the default purchase button. The Web Purchase Button opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.
 
-To add a Web Purchase Button to your paywall, you can use the Button component and select the 'Web Purchase' option.
+To add a Web Purchase Button to your paywall, you can use the Button component and select 'Navigate to' -> 'Web Purchase'.
 
 <YouTubeEmbed videoId="XF9cbvyiK48" title="Web Purchase Button" />
 

--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -5,7 +5,7 @@ sidebar_label: Web Purchase Button
 ---
 
 :::info Introduction
-Read more about the new Web Paywall Button in our [blog post](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons) announcement.
+Read more about the new Web Purchase Button in our [blog post](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons) announcement.
 :::
 
 RevenueCat Paywalls v2 supports the Web Purchase Button as a button destination as an alternative to the default purchase button. The Web Purchase Button opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.

--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -1,18 +1,18 @@
 ---
-title: Web Paywall Button
-slug: web-paywall-button
-sidebar_label: Web Paywall Button
+title: Web Purchase Button
+slug: web-purchase-button
+sidebar_label: Web Purchase Button
 ---
 
 :::info Introduction
 Read more about the new Web Paywall Button in our [blog post](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons) announcement.
 :::
 
-RevenueCat Paywalls v2 supports the Web Paywall Button as a button destination as an alternative to the default purchase button. The Web Paywall Buttons opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.
+RevenueCat Paywalls v2 supports the Web Purchase Button as a button destination as an alternative to the default purchase button. The Web Purchase Button opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.
 
-To add a Web Paywall Button to your paywall, you can use the Web Paywall Button component.
+To add a Web Purchase Button to your paywall, you can use the Web Purchase Button component.
 
-<YouTubeEmbed videoId="XF9cbvyiK48" title="Web Paywall Button" />
+<YouTubeEmbed videoId="XF9cbvyiK48" title="Web Purchase Button" />
 
 ## Supported SDK versions
 

--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -10,7 +10,7 @@ Read more about the new Web Purchase Button in our [blog post](https://revenueca
 
 RevenueCat Paywalls v2 supports the Web Purchase Button as a button destination as an alternative to the default purchase button. The Web Purchase Button opens an external link from your app to a [Web Billing](/web/web-billing/overview) paywall.
 
-To add a Web Purchase Button to your paywall, you can use the Web Purchase Button component.
+To add a Web Purchase Button to your paywall, you can use the Button component and select the 'Web Purchase' option.
 
 <YouTubeEmbed videoId="XF9cbvyiK48" title="Web Purchase Button" />
 

--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -16,7 +16,7 @@ To add a Web Purchase Button to your paywall, you can use the Web Purchase Butto
 
 ## Supported SDK versions
 
-| RevenueCat SDK           | Version required for Web Paywall Button | 
+| RevenueCat SDK           | Version required for Web Purchase Button | 
 | :----------------------- | :--------------------------------------------- |
 | purchases-ios             | 5.22.2 and up                 |
 | react-native-purchases | 8.9.6 and up                 | 

--- a/docs/web/faq.mdx
+++ b/docs/web/faq.mdx
@@ -18,10 +18,10 @@ Get started with Web Billing by following the [setup guide](/web/web-billing/ove
 
 Notable updates to external web payments and RevenueCat Web Billing.
 
-| Date           | Description                                                                                                                                                                                                                                                                                                             |
-| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| May 1, 2025    | Added support for Web Paywalls as a [button destination](/tools/paywalls-v2/creating-paywalls/web-paywall-button) in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Purchase Buttons. |
-| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling.                 |
+| Date           | Description                                                                                                                                                                                                                                                                                                              |
+| :------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| May 1, 2025    | Added support for Web Paywalls as a [button destination](/tools/paywalls-v2/creating-paywalls/web-purchase-button) in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Purchase Buttons. |
+| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling.                  |
 
 ## FAQs
 

--- a/docs/web/faq.mdx
+++ b/docs/web/faq.mdx
@@ -18,10 +18,10 @@ Get started with Web Billing by following the [setup guide](/web/web-billing/ove
 
 Notable updates to external web payments and RevenueCat Web Billing.
 
-| Date           | Description                                                                                                                                                                                                                                                                                                            |
-| :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| May 1, 2025    | Added support for Web Paywalls as a [button destination](/tools/paywalls-v2/creating-paywalls/web-paywall-button) in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Paywall Buttons. |
-| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling.                |
+| Date           | Description                                                                                                                                                                                                                                                                                                             |
+| :------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| May 1, 2025    | Added support for Web Paywalls as a [button destination](/tools/paywalls-v2/creating-paywalls/web-paywall-button) in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Purchase Buttons. |
+| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling.                 |
 
 ## FAQs
 

--- a/docs/web/faq.mdx
+++ b/docs/web/faq.mdx
@@ -18,10 +18,10 @@ Get started with Web Billing by following the [setup guide](/web/web-billing/ove
 
 Notable updates to external web payments and RevenueCat Web Billing.
 
-| Date           | Description                                                                                                                                                                                                                                                                                             |
-| :------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| May 1, 2025    | Added support for Web Paywalls as a button destination in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Paywall Buttons.                                             |
-| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling. |
+| Date           | Description                                                                                                                                                                                                                                                                                                            |
+| :------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| May 1, 2025    | Added support for Web Paywalls as a [button destination](/tools/paywalls-v2/creating-paywalls/web-paywall-button) in iOS 5.22.2, React Native 8.9.6, Flutter: 8.7.5, KMP: 1.7.7+13.29.1. Read more in our [blog post](https://www.revenuecat.com/blog/growth/introducing-web-paywall-buttons/) on Web Paywall Buttons. |
+| April 30, 2025 | U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. Read more in our [blog post](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) on the ruling.                |
 
 ## FAQs
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -125,7 +125,7 @@ const paywallsCategory = Category({
           items: [
             Page({ slug: "components" }),
             Page({ slug: "component-properties" }),
-            Page({ slug: "web-paywall-button" }),
+            Page({ slug: "web-purchase-button" }),
             Page({ slug: "variables" }),
             Page({ slug: "localization" }),
             Page({ slug: "customer-states" }),

--- a/sidebars.js
+++ b/sidebars.js
@@ -113,16 +113,6 @@ const paywallsCategory = Category({
   itemsPathPrefix: "",
   items: [
     SubCategory({
-      label: "RevenueCat Paywalls (Recommended)",
-      slug: "tools/paywalls",
-      itemsPathPrefix: "tools/paywalls/",
-      items: [
-        Page({ slug: "installation" }),
-        Page({ slug: "creating-paywalls" }),
-        Page({ slug: "displaying-paywalls" }),
-      ],
-    }),
-    SubCategory({
       label: "RevenueCat Paywalls v2 (Beta)",
       slug: "tools/paywalls-v2",
       itemsPathPrefix: "tools/paywalls-v2/",
@@ -135,14 +125,25 @@ const paywallsCategory = Category({
           items: [
             Page({ slug: "components" }),
             Page({ slug: "component-properties" }),
+            Page({ slug: "web-paywall-button" }),
             Page({ slug: "variables" }),
-            Page({ slug: "customer-states" }),
             Page({ slug: "localization" }),
+            Page({ slug: "customer-states" }),
             Page({ slug: "app-review" }),
           ],
         }),
         Page({ slug: "displaying-paywalls" }),
         Page({ slug: "change-log" }),
+      ],
+    }),
+    SubCategory({
+      label: "RevenueCat Paywalls",
+      slug: "tools/paywalls",
+      itemsPathPrefix: "tools/paywalls/",
+      items: [
+        Page({ slug: "installation" }),
+        Page({ slug: "creating-paywalls" }),
+        Page({ slug: "displaying-paywalls" }),
       ],
     }),
     SubCategory({


### PR DESCRIPTION
## Motivation / Description

Expand surface area of the Web ~Paywall~ Purchase Button and additional FAQ details on web purchases

## Changes introduced

- Adds a new Web Purchase Button page
- New section in Components page
- List Paywalls v2 first and remove v1 recommended text

## Linear ticket (if any)

## Additional comments
