### PR TITLE
docs: update App Store policy warning for US court ruling

### DIFF
--- a/docs/web/integrations/stripe.mdx
+++ b/docs/web/integrations/stripe.mdx
@@ -7,7 +7,11 @@ hidden: false
 
 RevenueCat currently supports web payments through Stripe. This allows you to let users subscribe on your own website using Stripe, and automatically unlock access based on the Stripe subscription through the _Purchases SDK_.
 
-Remember that it is against Apple's App Store terms to provide a different system than in-app purchases for digital goods. Make sure you don't promote your web subscriptions from inside your app. Your app may get rejected, or banned.
+:::info April 2025 U.S. District Court Ruling on External Payment Options
+A recent U.S. District Court ruling found Apple in violation of a 2021 injunction meant to allow developers to direct users to external payment options, like Web Billing. As a result, iOS developers are now permitted to guide users to web-based payment flows without additional Apple fees or restrictive design requirements. You can [find more details on the RevenueCat blog](https://revenuecat.com/blog/growth/introducing-web-paywall-buttons).
+:::
+
+For apps available outside the U.S. App Store, Apple still requires that digital goods and subscriptions be purchased through in-app purchases. Promoting or linking to alternative payment methods within the app for non-U.S. users may lead to app review rejection or removal. Always ensure external payment links are shown only to eligible U.S. users.
 
 Before launching your Stripe integration, be sure to read the limitations that apply to [working with web payments](#working-with-web-payments).
 


### PR DESCRIPTION
## Motivation / Description

The Stripe Billing page doesn't refer the new ruling as Web Billing does. 

## Changes introduced

Updates:
- removed/reworded warning about App Store terms
- added court ruling info block about external payment options (same as Web Billing)

## Linear ticket (if any)

n/a

## Additional comments

n/a

## Screenshots
Web Billing as of today
-
<img width="1145" alt="Screenshot 2025-05-06 at 15 30 46" src="https://github.com/user-attachments/assets/53b33134-be0a-409c-93ce-0594a12c61bb" />


Suggested update to Stripe Billing
-

<img width="1123" alt="Screenshot 2025-05-06 at 15 28 56" src="https://github.com/user-attachments/assets/2a34b663-71b7-47d1-878c-36d03b7fe83b" />

