### PR TITLE
[Update] Added missing currencies to Dashboard displayed metrics

### DIFF
--- a/docs/dashboard-and-metrics/display-currency.md
+++ b/docs/dashboard-and-metrics/display-currency.md
@@ -36,6 +36,8 @@ We currently support the following display currencies:
 8. KRW: South Korean Won
 9. CNY: Chinese Yuan
 10. MXN: Mexican Peso
+11. SEK: Swedish Krona
+12. PLN: Polish Zloty
 
 ## How we convert purchases from one currency to another
 


### PR DESCRIPTION
## Motivation / Description

We support a couple extra currencies currently:
- RC App shows [this](https://github.com/RevenueCat/revenuecat-app/blob/12c10760abf24354b87fea1e5e8b5f19874a59ce/src/common/config.ts#L94)
- Khepri matches with [this](https://github.com/RevenueCat/khepri/blob/5ede4589145941065daf4c7f7e6d19fdafeede58/khepri/dal/domains/exchange_rates/model/daily_supported_exchange_rates.py#L16) 

## Changes introduced

Added
```
SEK: Swedish Krona
PLN: Polish Zloty
```
to the list

## Linear ticket (if any)
n/a

## Additional comments
n/a

## Visuals

RC App in Date/Region settings
-
<img width="400" alt="Dashboard settings" src="https://github.com/user-attachments/assets/4b798a17-9b39-4d57-855a-61f9bdd47dc7" />

Current docs
-

As seen [here](https://www.revenuecat.com/docs/dashboard-and-metrics/display-currency#supported-currencies)

<img width="426" alt="Screenshot 2025-05-09 at 19 06 41" src="https://github.com/user-attachments/assets/5bbb4e6c-d5b0-4654-a3e3-bfa091d3c65a" />


Updated docs
-
<img width="421" alt="updated" src="https://github.com/user-attachments/assets/59ab4a4d-f5a4-4168-a088-cb4fd4d7c37a" />

