### PR TITLE
adds near-white background to images to support dark mode

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -57,15 +57,17 @@
   --ifm-color-success-contrast-background: #f6fefb;
   --ifm-color-success-contrast-foreground: #000000;
 
-  --ifm-heading-font-family: "Object Sans", "system-ui", "-apple-system",
-    "Segoe UI", "Roboto", "Ubuntu", "Cantarell", "Noto Sans", "sans-serif",
-    "BlinkMacSystemFont", "'Segoe UI'", "Helvetica", "Arial", "sans-serif",
-    "'Apple Color Emoji'", "'Segoe UI Emoji'", "'Segoe UI Symbol'";
-
-  --ifm-font-family-base: "system-ui", "-apple-system", "Segoe UI", "Roboto",
-    "Ubuntu", "Cantarell", "Noto Sans", "sans-serif", "BlinkMacSystemFont",
-    "'Segoe UI'", "Helvetica", "Arial", "sans-serif", "'Apple Color Emoji'",
+  --ifm-heading-font-family:
+    "Object Sans", "system-ui", "-apple-system", "Segoe UI", "Roboto", "Ubuntu",
+    "Cantarell", "Noto Sans", "sans-serif", "BlinkMacSystemFont", "'Segoe UI'",
+    "Helvetica", "Arial", "sans-serif", "'Apple Color Emoji'",
     "'Segoe UI Emoji'", "'Segoe UI Symbol'";
+
+  --ifm-font-family-base:
+    "system-ui", "-apple-system", "Segoe UI", "Roboto", "Ubuntu", "Cantarell",
+    "Noto Sans", "sans-serif", "BlinkMacSystemFont", "'Segoe UI'", "Helvetica",
+    "Arial", "sans-serif", "'Apple Color Emoji'", "'Segoe UI Emoji'",
+    "'Segoe UI Symbol'";
 
   --primary-action-color: rgb(87, 108, 219);
 }
@@ -230,6 +232,7 @@ h4 {
     rgba(0, 0, 0, 0.1) 0px 1px 3px 0px,
     rgba(0, 0, 0, 0.05) 0px 0.5px 0px 0px,
     rgba(0, 0, 0, 0.05) 0px 0px 0px 0.5px;
+  background-color: #f5f5f5;
 }
 
 html[data-theme="dark"].markdown img {


### PR DESCRIPTION
## Motivation / Description
Transparent images look bad in dark mode: https://revenuecat.slack.com/archives/C036H1WM0T0/p1747066541481519

## Changes introduced
Adds near-white background to images (#f5f5f5)—useful for transparent images.

## Linear ticket (if any)

## Additional comments
