### PR TITLE
Added note from the Web Billing email translation limitation

### DIFF
--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -41,6 +41,7 @@ Web Billing currently has a number of known limitations. Most notably:
 - There is no support for sales tax or VAT calculation.
 - There is no support for discounts or other offers.
 - There is no support for our Paywall templates yet.
+- There is no support for translated email (these are currently only sent in English, regardless of the selected locale).
 
 ## Web Billing vs. Stripe Billing integration
 


### PR DESCRIPTION
## Motivation / Description

Web Billing (as per this [Slack thread](https://revenuecat.slack.com/archives/C05TUASTSG4/p1740160779944999?thread_ts=1739998199.712349&cid=C05TUASTSG4)) does not support translated emails - yet! This change is to let customer knows and have ourselves a place to reference this limitation.

## Changes introduced

Added a new bullet list item to reflect this

## Linear ticket (if any)
n/a

## Additional comments
n/a