### PR TITLE
Missing Web Purchase Links renames

### DIFF
--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -28,9 +28,9 @@ If you run a dynamic web app and have access to the code, you should consider in
 
 [Get started with the Web SDK](web-sdk)
 
-#### Web Payment Links (low code)
+#### Web Purchase Links
 
-If you want a low-code way to collect payments from customers, you can use Web Payment Links, which provide a customizable purchase flow hosted by RevenueCat. This is useful if you need to distribute payment links from static systems such as emails, social media, or a static landing page.
+If you want a low-code way to collect payments from customers, you can use Web Purchase Links, which provide a customizable purchase flow hosted by RevenueCat. This is useful if you need to distribute payment links from static systems such as emails, social media, or a static landing page.
 
 [Get started with Web Purchase Links](web-purchase-links)
 

--- a/docs/web/web-billing/web-purchase-links.mdx
+++ b/docs/web/web-billing/web-purchase-links.mdx
@@ -1,5 +1,5 @@
 ---
-title: Web Purchase Links (low code)
+title: Web Purchase Links
 slug: web-purchase-links
 excerpt: Generate a RevenueCat hosted paywall and checkout flow with just a few clicks
 hidden: false


### PR DESCRIPTION
## Motivation / Description

Two renames were missed and also removing the "low code" mentions.
