### PR TITLE
Add warning about Web Purchase Button limitations on Android devices

### DIFF
--- a/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
+++ b/docs/tools/paywalls-v2/creating-paywalls/web-purchase-button.mdx
@@ -24,6 +24,10 @@ To add a Web Purchase Button to your paywall, you can use the Button component a
 | purchases-kmp             | 1.7.7+13.29.1 and up                  |
 | Other SDKs         | Not supported                  |
 
+:::warning
+Offering a web checkout experience on Android is not allowed, so **the Web Purchase Button will not appear on Android devices**. The [recent court ruling](https://www.revenuecat.com/blog/growth/apple-anti-steering-ruling-monetization-strategy/) only applies to U.S. iOS apps.
+:::
+
 ## Considerations
 
 For more information about support for external web purchases, see [FAQs](/web/faqs).


### PR DESCRIPTION
* Clarified that the Web Purchase Button will not appear on Android due to legal restrictions.
* Included a link to the relevant court ruling for context.

![image](https://github.com/user-attachments/assets/dc9a73dd-4737-48fe-98a1-e4d285e27a04)