### PR TITLE
Update "Documentation" menu -> "Categories"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
         },
         items: [
           {
-            label: "Documentation",
+            label: "Categories",
             to: "/welcome/overview",
             items: [
               {


### PR DESCRIPTION
## Motivation / Description

Rik mentioned the navbar 'Documentation' grouping isn't really clear that it's showing multiple sets of docs. This is a start at trying to make it more clear

## Changes introduced

- Change 'Documentation' to 'Categories'

## Linear ticket (if any)

## Additional comments
