### PR TITLE
Self-serve delete accounts messaging

### DIFF
--- a/docs/welcome/set-up-revenuecat/account-management.md
+++ b/docs/welcome/set-up-revenuecat/account-management.md
@@ -69,4 +69,4 @@ You can select a currency to be used across the dashboard. See [Display Currency
 
 To delete your RevenueCat account, you'll first need to delete **all of your [Projects](/projects/overview)**. Please note, deleting any active Projects will prevent users from accessing their purchases via the RevenueCat SDK but **will not** cancel any of your customer's active subscriptions. RevenueCat will not delete your projects for you.
 
-Once your projects have been deleted, reach out to RevenueCat Support via the dashboard [Contact Us](https://app.revenuecat.com/settings/support) form in your account settings and request your account to be deleted.
+Once your projects have been deleted, you can delete your account via your [account settings](https://app.revenuecat.com/settings/account).


### PR DESCRIPTION
## Motivation / Description

Developers can self-serve delete their account now

## Changes introduced

- updates wording to push self-serve instead of contacting support 

## Linear ticket (if any)

## Additional comments
