### PR TITLE
Apple Shared Secret in guide setup

### DIFF
--- a/docs/getting-started/displaying-products.mdx
+++ b/docs/getting-started/displaying-products.mdx
@@ -11,6 +11,13 @@ If you've [configured Offerings](/getting-started/entitlements) in RevenueCat, y
 Before products and offerings can be fetched from RevenueCat, be sure to initialize the Purchases SDK by following our [Quickstart](/getting-started/quickstart) guide.
 :::
 
+:::info For Apple App Store apps
+If you are connecting an iOS or macOS app, make sure you have added both your App Store Connect App-Specific Shared Secret and your In-App Purchase Key in the RevenueCat dashboard. These are required for validating subscriptions and may be necessary for correct product fetching in some configurations.
+
+- [How to find your shared secret →](/service-credentials/itunesconnect-app-specific-shared-secret)
+- [How to find your in-app purchase key →](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration)
+  :::
+
 ## Fetching Offerings
 
 Offerings are fetched through the SDK based on their [configuration](/offerings/overview) in the RevenueCat dashboard.

--- a/docs/getting-started/displaying-products.mdx
+++ b/docs/getting-started/displaying-products.mdx
@@ -12,7 +12,7 @@ Before products and offerings can be fetched from RevenueCat, be sure to initial
 :::
 
 :::info For Apple App Store apps
-If you are connecting an iOS or macOS app, make sure you have added both your App Store Connect App-Specific Shared Secret and your In-App Purchase Key in the RevenueCat dashboard. These are required for validating subscriptions and may be necessary for correct product fetching in some configurations.
+If you are connecting an iOS or macOS app, make sure you have added both your App Store Connect App-Specific Shared Secret and your In-App Purchase Key in the RevenueCat dashboard. These are required for validating subscriptions and fetching offerings/products.
 
 - [How to find your shared secret →](/service-credentials/itunesconnect-app-specific-shared-secret)
 - [How to find your in-app purchase key →](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration)

--- a/docs/offerings/troubleshooting.mdx
+++ b/docs/offerings/troubleshooting.mdx
@@ -50,6 +50,14 @@ Since the actual products that your users purchase can only be retrieved from th
       platforms: ["ios"],
     },
     {
+      title: "Add App-Specific Shared Secret and In-App Purchase Key",
+      description:
+        "Make sure you have added both your <a href='https://www.revenuecat.com/docs/service-credentials/itunesconnect-app-specific-shared-secret' target='_blank' rel='noopener noreferrer'>App Store Connect App-Specific Shared Secret</a> and your <a href='https://www.revenuecat.com/docs/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration' target='_blank' rel='noopener noreferrer'>In-App Purchase Key</a> in the RevenueCat dashboard. These are required for validating subscriptions and fetching offerings/products.",
+      caption:
+        "Missing either of these credentials can prevent products and offerings from being fetched in your app.",
+      platforms: ["ios"],
+    },
+    {
       title: "Check Google Play Console Agreements",
       description:
         "Verify that all agreements have been signed and banking details have been completed in Google Play Console.",


### PR DESCRIPTION
## Motivation / Description

Some customers are struggling to get offerings/products and it turns out this key is missing. Bringing it closer to them during the guide in order to try and be more explicit about it

## Changes introduced

Added a new block on the `docs/getting-started/displaying-products`

## Linear ticket (if any)
n/a

## Additional comments
n/a

## Visuals

Before
-
![Screenshot 2025-05-21 at 16 54 03](https://github.com/user-attachments/assets/69298368-29df-4c47-8222-201d74b11c1f)

After
-

![Screenshot 2025-05-21 at 16 57 57](https://github.com/user-attachments/assets/b33fb475-3c6a-432b-b96e-9fe09211f444)

Troubleshooting guide
-
![Screenshot 2025-05-21 at 17 14 09](https://github.com/user-attachments/assets/db185c1c-7348-4d6e-933d-fddade3e582e)

