### PR TITLE
[PSP-183] Add Paddle API key permissions in the integration doc

### DIFF
--- a/docs/web/integrations/paddle.mdx
+++ b/docs/web/integrations/paddle.mdx
@@ -15,6 +15,28 @@ Paddle has a different environment for sandbox and production. As environments a
 
 ![](/images/paddle/new-app.png)
 
+### 1.1. Defining Paddle API Key permissions
+
+The minimum list of required [permissions](https://developer.paddle.com/api-reference/about/permissions) for the created API key are:
+
+<details>
+  <summary>Show list</summary>
+    - `product.read`
+    - `price.read`
+    - `discount.read`
+    - `customer.read`
+    - `address.read`
+    - `business.read`
+    - `payment_method.read`
+    - `transaction.read`
+    - `subscription.read`
+    - `adjustment.read`	
+    - `notification.read`	
+    - `notification_setting.read`
+    - `notification_setting.write`
+</details>
+
+
 ## 2. Create products and prices on Paddle
 
 You can create products and prices following the [Paddle Product Setup](/getting-started/entitlements/paddle-products) guide.


### PR DESCRIPTION
## Motivation / Description

Added a subsection to specify the Paddle API Keys premissions when defining it on Paddle's dashboard:

Collapsed:

<img width="865" alt="Screenshot 2025-05-22 at 18 41 38" src="https://github.com/user-attachments/assets/d11587eb-a5c5-46bd-91c0-2f02677b364a" />


Opened:

<img width="907" alt="Screenshot 2025-05-22 at 18 40 53" src="https://github.com/user-attachments/assets/c3500679-6655-457d-8fcf-849e7ec1ac70" />

Check it here: https://dev-docs.revenuecat.com/pr-840/web/integrations/paddle

## Changes introduced

## Linear ticket (if any)

## Additional comments
