### PR TITLE
Update google-server-notifications.md

### DIFF
--- a/docs/platform-resources/server-notifications/google-server-notifications.md
+++ b/docs/platform-resources/server-notifications/google-server-notifications.md
@@ -24,7 +24,7 @@ You can enable it [here](https://console.cloud.google.com/flows/enableapi?apiid=
 - Where: RevenueCat Dashboard
 - Project Page ➡️ Google Play App Settings
 
-Directly beneath where the Service Credentials JSON object is added, a list of possible Pub/Sub topics to use will be visible. You can either choose an existing one, or let RevenueCat create a new one.
+Directly beneath where the Service Credentials JSON object is added, a list of possible Pub/Sub topics to use will be visible. You can either choose an existing one, or let RevenueCat create a new one. You then want to make sure to add and grant the service account `google-play-developer-notifications@system.gserviceaccount.com` the Pub/Sub Publisher role on that specific topic via Permissions -> Add Principal -> add `google-play-developer-notifications@system.gserviceaccount.com` -> give it the role Pub/Sub Publisher
 
 Click '**Connect to Google**'. You should see a generated Google Cloud Pub/Sub Topic ID, as in the image below. If you don’t, try refreshing the page to get it to populate. Copy this topic ID to your clipboard.
 


### PR DESCRIPTION
## Motivation / Description
Sometimes pub/sub will not work for some devs due to not having `google-play-developer-notifications@system.gserviceaccount.com` as a publisher to their Pub/Sub topic id. Adding this as a step in our docs

## Additional comments
This has been seen in several tickets already:
https://revenuecat.zendesk.com/agent/tickets/53520
https://revenuecat.zendesk.com/agent/tickets/56901
https://revenuecat.zendesk.com/agent/tickets/58034

Google support mentions this as well here: https://support.google.com/googleplay/android-developer/thread/210693545/real-time-developer-notifications-is-not-working?hl=en
https://developer.android.com/google/play/billing/getting-ready#grant-rights