### PR TITLE
Update Expo docs

### DIFF
--- a/code_blocks/getting-started/getting-started_6.ts
+++ b/code_blocks/getting-started/getting-started_6.ts
@@ -1,5 +1,6 @@
 import { Platform, useEffect } from 'react-native';
-import Purchases from 'react-native-purchases';
+import { useEffect } from 'react';
+import Purchases, { LOG_LEVEL } from 'react-native-purchases';
 
 //...
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -7,29 +7,41 @@ hidden: false
 
 Expo is a framework for building React Native apps. It's a popular choice for rapidly iterating on your app, while letting Expo take care of all the platform-specific code.
 
-To use and test RevenueCat with Expo, you'll need to create an Expo development build.
+To use and test RevenueCat with Expo, you'll need to create an Expo development build. Follow the instructions below and learn more about Expo development builds [here](https://docs.expo.dev/develop/development-builds/introduction/).
 
 ## Create an Expo development build
 
-### Getting started
+### Install Expo CLI and development dependencies
 
-Either create a new project or use an existing project.
-
-### Install dependencies
-
-Start by installing Expo CLI:
+Start by installing [Expo CLI](https://docs.expo.dev/more/expo-cli/):
 
 ```
 npm install expo -g
 ```
 
-Install expo-dev-client:
+and then install [Expo DevClient](https://docs.expo.dev/versions/latest/sdk/dev-client/):
 
 ```
 npx expo install expo-dev-client
 ```
 
-Install RevenueCat's `react-native-purchases` and `react-native-purchases-ui`:
+### Get started with an Expo project
+
+Either create a new Expo project with the following command:
+
+```
+npx create-expo-app@latest
+```
+
+or use an existing Expo project. Ensure you're in the project directory for the next steps:
+
+```
+cd <expo-project-directory>
+```
+
+### Install RevenueCat's SDKs
+
+Install RevenueCat's `react-native-purchases` for core functionality and `react-native-purchases-ui` for UI components like [Paywalls](/docs/tools/paywalls-v2), [Customer Center](/docs/tools/customer-center), and more.
 
 Either run:
 
@@ -48,36 +60,65 @@ or update your package.json with the [latest package versions](https://github.co
 }
 ```
 
-### RevenueCat Configuration
+### RevenueCat Dashboard Configuration
 
-#### Configure a new project, add products, and create an offering
+#### Configure a new project
 
-TODO: link to relevant docs
+RevenueCat projects are top-level containers for your apps, products, entitlements, paywalls, and more. If you don't already have a RevenueCat project for your app, [create one here](/docs/projects/overview).
 
-#### Configure a paywall
+#### Connect to a Store (Apple, Google, Web, etc.)
 
-TODO: link to paywalls v2 docs
+Depending on which platform you're building for, you'll need to connect your RevenueCat project to one, or multiple, stores. Set up your project's supported stores [here](/docs/projects/connect-a-store).
+
+#### Add Products
+
+For each store you're supporting, you'll need to add the products you plan on offering to your customers. Set up your products for each store [here](/docs/offerings/products/setup-index).
+
+#### Create an Entitlement
+
+An entitlement represents a level of access, features, or content that a customer is "entitled" to. When customers purchase a product, they're granted an entitlement. Create an entitlement [here](/docs/getting-started/entitlements). Then, [attach your products](/docs/getting-started/entitlements#attaching-products-to-entitlements) to your new entitlement.
+
+#### Create an Offering
+
+An offering is a collection of products that are "offered" to your customers on your paywall. Create an offering for your products [here](/docs/offerings/offerings/overview).
+
+#### Configure a Paywall
+
+A paywall is where your customers can purchase your products. RevenueCat's Paywalls allow you to remotely build and configure your paywall without any code changes or app updates. Create a paywall [here](/docs/tools/paywalls-v2).
+
+### RevenueCat SDK Configuration
 
 #### Initialize the SDK
 
-Once you've installed the RevenueCat SDK, you'll need to configure it. Add the following code to the entry point of your app. More information about configuring the SDK can be found [here](../configuring-sdk).
+Once you've installed the RevenueCat SDK, you'll need to configure it. Add the following code to the entry point of your app and be sure to replace `<revenuecat_project_platform_api_key>` with your [project's API keys](https://www.revenuecat.com/docs/projects/authentication).
+
+More information about configuring the SDK can be found [here](../configuring-sdk).
 
 import expoContent from "!!raw-loader!@site/code_blocks/getting-started/getting-started_6.ts";
 
 <RCCodeBlock tabs={[{ type: "ts", content: expoContent, name: "Expo" }]} />
 
+#### Identify a user and check subscription status
+
+RevenueCat is the single source of truth for your customer's subscription status across all platforms. Learn more about the different ways to identify your customers to RevenueCat [here](/docs/customers/identifying-customers).
+
+Then, [check the customer's subscription status](/docs/customers/customer-info) by fetching the [CustomerInfo object](/docs/customers/customer-info#:~:text=CustomerInfo%20Reference):
+
+import content6 from "!!raw-loader!@site/code_blocks/customers/customer-info_6.js";
+
+<RCCodeBlock tabs={[{ type: "ts", content: content6, name: "Expo" }]} />
+
+and inspecting the `entitlements` object to see if the customer is subscribed to your entitlement:
+
+import content14 from "!!raw-loader!@site/code_blocks/customers/customer-info_14.js";
+
+<RCCodeBlock tabs={[{ type: "ts", content: content14, name: "Expo" }]} />
+
 #### Present a paywall
 
-TODO: link to present paywall docs
+If the customer is not subscribed to your entitlement, you can present a paywall to them where they can purchase your products.
 
-```javascript
-<Button
-  title="Purchase"
-  onPress={() => {
-    PurchasesUI.presentPaywall();
-  }}
-/>
-```
+There are several ways to present a paywall in Expo, each with different use cases, so please review the [React Native Paywalls documentation](/docs/tools/paywalls-v2/displaying-paywalls#react-native).
 
 ### Testing your app
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -244,4 +244,4 @@ npx expo start
 
 ## Expo Go
 
-Expo Go is not supported at this time.
+[Expo Go](https://expo.dev/go) is a sandbox that allows you to rapidly prototype your app. However, Expo Go does not run native code, so testing in-app purchases is not supported. Once you've added RevenueCat's SDKs to your app, please use a [development build](/docs/getting-started/installation/expo#create-an-expo-development-build) for testing.

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -152,6 +152,10 @@ Open in simulator
 
 `npx expo start`, choose the server in the iOS simulator
 
+## Expo Go
+
+Expo Go is not supported at this time.
+
 # OLD CONTENT
 
 ## I don't know if it's relevant anymore

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -220,6 +220,28 @@ npx expo start
 
 Finally, choose the local development server in the iOS simulator.
 
+#### Testing on Android device or emulator
+
+To test on an Android device, you'll need to build the app for a physical device or Android emulator as described [here](https://docs.expo.dev/tutorial/eas/android-development-build/).
+
+Please ensure that `developmentClient` in your `eas.json` file is set to true under the `build.development` profile. Then, build the app:
+
+```
+eas build --platform android --profile development
+```
+
+Enter your app's application ID matches your RevenueCat config and Google Play Console. Choose "Yes" when asked if you want to create a new Android Keystore.
+
+Once the build completes, you can run the application on the device or emulator. To run the app on an [Android device](https://docs.expo.dev/tutorial/eas/android-development-build/#android-device), install [Expo Orbit](https://expo.dev/orbit), connect your device to your computer, and [select your device](https://docs.expo.dev/tutorial/eas/android-development-build/#android-device:~:text=and%20Install%20button.-,Expo%20Orbit,-allows%20for%20seamless) from the Orbit menu. Alternatively, use the [provided QR code method](https://docs.expo.dev/tutorial/eas/android-development-build/#android-device:~:text=and%20Install%20button.-,Expo%20Orbit,-allows%20for%20seamless).
+
+To run the app on an [Android emulator](https://docs.expo.dev/tutorial/eas/android-development-build/#android-emulator), choose "Yes" in the terminal after the build completes.
+
+After the app is running, you'll need to start the Expo server:
+
+```
+npx expo start
+```
+
 ## Expo Go
 
 Expo Go is not supported at this time.

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -26,16 +26,26 @@ npm install expo -g
 Install expo-dev-client:
 
 ```
-npm install expo-dev-client
+npx expo install expo-dev-client
 ```
 
-Install `react-native-purchases`, `react-native-purchases-ui`:
+Install RevenueCat's `react-native-purchases` and `react-native-purchases-ui`:
 
-```
 Either run:
-npm install react-native-purchases react-native-purchases-ui
 
-or update your package.json
+```
+npx expo install react-native-purchases react-native-purchases-ui
+```
+
+or update your package.json with the [latest package versions](https://github.com/RevenueCat/react-native-purchases/releases):
+
+```json
+{
+  "dependencies": {
+    "react-native-purchases": "latest_version",
+    "react-native-purchases-ui": "latest_version"
+  }
+}
 ```
 
 ### RevenueCat Configuration
@@ -50,19 +60,11 @@ TODO: link to paywalls v2 docs
 
 #### Initialize the SDK
 
-TODO: link to configure docs
+Once you've installed the RevenueCat SDK, you'll need to configure it. Add the following code to the entry point of your app. More information about configuring the SDK can be found [here](../configuring-sdk).
 
-```javascript
-export default function App() {
-  useEffect(() => {
-    Purchases.setLogLevel(Purchases.LOG_LEVEL.DEBUG);
+import expoContent from "!!raw-loader!@site/code_blocks/getting-started/getting-started_6.ts";
 
-    Purchases.configure({ apiKey: <your-api-key> });
-  }, []);
-
-  return <Stack />;
-}
-```
+<RCCodeBlock tabs={[{ type: "ts", content: expoContent, name: "Expo" }]} />
 
 #### Present a paywall
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -167,13 +167,11 @@ After logging in, initialize the EAS configuration:
 eas init
 ```
 
-The command will ask you to choose the platforms you want to build for. Next, run:
+Then run the following command, which will prompt you to select the platforms you'd like to configure for EAS Build.
 
 ```
 eas build:configure
 ```
-
-You'll be prompted to select the platforms you'd like to configure for EAS Build.
 
 #### Testing on iOS simulator
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -60,6 +60,21 @@ or update your package.json with the [latest package versions](https://github.co
 }
 ```
 
+:::info
+After installing RevenueCat's SDKs, you **must** run the full build process to ensure all dependencies are installed. Hot reloading without building will result in an error that looks like this:
+
+```
+Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.
+```
+
+To fix this, run the [full build process](https://docs.expo.dev/tutorial/eas/configure-development-build/) for your platform. For example, if you're building for the iOS simulator, run:
+
+```
+eas build --platform ios --profile ios-simulator
+```
+
+:::
+
 ### RevenueCat Dashboard Configuration
 
 #### Configure a new project

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -1,0 +1,175 @@
+---
+title: Expo
+slug: expo
+excerpt: Instructions for using RevenueCat with Expo
+hidden: false
+---
+
+Expo is a framework for building React Native apps. It's a popular choice for rapidly iterating on your app, while letting Expo take care of all the platform-specific code.
+
+To use and test RevenueCat with Expo, you'll need to create an Expo development build.
+
+## Create an Expo development build
+
+### Getting started
+
+Either create a new project or use an existing project.
+
+### Install dependencies
+
+Start by installing Expo CLI:
+
+```
+npm install expo -g
+```
+
+Install expo-dev-client:
+
+```
+npm install expo-dev-client
+```
+
+Install `react-native-purchases`, `react-native-purchases-ui`:
+
+```
+Either run:
+npm install react-native-purchases react-native-purchases-ui
+
+or update your package.json
+```
+
+### RevenueCat Configuration
+
+#### Configure a new project, add products, and create an offering
+
+TODO: link to relevant docs
+
+#### Configure a paywall
+
+TODO: link to paywalls v2 docs
+
+#### Initialize the SDK
+
+TODO: link to configure docs
+
+```javascript
+export default function App() {
+  useEffect(() => {
+    Purchases.setLogLevel(Purchases.LOG_LEVEL.DEBUG);
+
+    Purchases.configure({ apiKey: <your-api-key> });
+  }, []);
+
+  return <Stack />;
+}
+```
+
+#### Present a paywall
+
+TODO: link to present paywall docs
+
+```javascript
+<Button
+  title="Purchase"
+  onPress={() => {
+    PurchasesUI.presentPaywall();
+  }}
+/>
+```
+
+### Testing your app
+
+To test, we'll use EAS to build the app for the simulator. You'll need to sign up at expo.dev and use the account below.
+
+For more information about EAS, see the [EAS docs](https://docs.expo.dev/tutorial/eas/introduction/).
+
+:::info
+You can also follow these instructions on Expo's docs: https://docs.expo.dev/tutorial/eas/configure-development-build/#initialize-a-development-build
+:::
+
+Get started by installing the EAS-CLI:
+
+```
+npm install -g eas-cli
+```
+
+Then login to EAS:
+
+```
+eas login
+```
+
+After logging in, initialize the EAS configuration:
+
+```
+eas init
+```
+
+The command will ask you to choose the platforms you want to build for.
+
+You can read more about
+
+#### Testing on iOS simulator
+
+Next, you'll need to update `eas.json` with the simulator build profile [as described here](https://docs.expo.dev/tutorial/eas/ios-development-build-for-simulators/).
+
+Your `eas.json` file might look like this:
+
+```json
+{
+  "cli": {
+    "version": ">= 7.3.0"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    },
+    "preview": {
+      "distribution": "internal"
+    },
+    "production": {},
+    "ios-simulator": {
+      "extends": "development",
+      "ios": {
+        "simulator": true
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}
+```
+
+`eas build --platform ios --profile ios-simulator`
+
+Building creates a container app with your installed dependencies. Once the build completes and you run it on the device, the app will hot reload with your local changes during development
+
+Enter bundle ID, matching RevenueCat config and App Store Connect
+
+Open in simulator
+
+`npx expo start`, choose the server in the iOS simulator
+
+# OLD CONTENT
+
+## I don't know if it's relevant anymore
+
+`react-native-purchases` works with with any Expo project when using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). A development build helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. It also enables you to only write JavaScript/TypeScript while letting Expo tools and services take care of everything else. The Android and iOS apps are built using Expo's build service and generate development and production binaries for testing and releasing.
+
+As of mid 2021, projects created with Expo now support in-app payments and are compatible with `react-native-purchases`. Running `npx expo install react-native-purchases` is all that needs to be done before you can start implementing RevenueCat into your app.
+
+Note: Expo's docs state that in-app purchases will only work on real Android and iOS devices which can make debugging more difficult. You can view the RevenueCat debug logs on Android with LogCat and iOS with Console.app.
+
+For more information, see our blog post [here](https://www.revenuecat.com/blog/in-app-puchase-expo-managed-workflow/).
+
+#### Bare workflow
+
+If you are using [bare workflow](https://docs.expo.dev/bare/overview/) (that is, your project is created using `react-native init`), [install `expo`](https://docs.expo.dev/bare/installing-expo-modules/) into your project and [leverage Expo CLI](https://docs.expo.dev/bare/using-expo-cli/) to use Expo tooling and services.
+
+The bare workflow gives developers complete native control but also allows the use of Expo libraries and services. The bare workflow is similar to a project you would get from `npx react-native init`.
+
+If you're planning on ejecting from Expo to use the bare workflow, upgrade your Expo version first, _then_ eject. It'll save you a whole lot of hassle.
+
+Get started with the bare workflow [here](https://docs.expo.dev/bare/overview/).

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -5,9 +5,19 @@ excerpt: Instructions for using RevenueCat with Expo
 hidden: false
 ---
 
+## What is RevenueCat?
+
+RevenueCat provides a backend and a wrapper around StoreKit and Google Play Billing to make implementing in-app purchases and subscriptions easy. With our SDK, you can build and manage your app business on any platform without having to maintain IAP infrastructure. You can read more about [how RevenueCat fits into your app](https://www.revenuecat.com/blog/where-does-revenuecat-fit-in-your-app) or you can [sign up free](https://app.revenuecat.com/signup) to start building.
+
+## Introduction
+
 Expo is a framework for building React Native apps. It's a popular choice for rapidly iterating on your app, while letting Expo take care of all the platform-specific code.
 
 To use and test RevenueCat with Expo, you'll need to create an Expo development build. Follow the instructions below and learn more about Expo development builds [here](https://docs.expo.dev/develop/development-builds/introduction/).
+
+:::info
+This guide is specific to Expo, but you may also find our [React Native guide](/getting-started/installation/reactnative) useful.
+:::
 
 ## Create an Expo development build
 
@@ -61,16 +71,10 @@ or update your package.json with the [latest package versions](https://github.co
 ```
 
 :::info
-After installing RevenueCat's SDKs, you **must** run the full build process to ensure all dependencies are installed. Hot reloading without building will result in an error that looks like this:
+After installing RevenueCat's SDKs, you **must** run the full build process as described below in the `Testing your app` section to ensure all dependencies are installed. Hot reloading without building will result in errors, such as:
 
 ```
 Invariant Violation: `new NativeEventEmitter()` requires a non-null argument.
-```
-
-To fix this, run the [full build process](https://docs.expo.dev/tutorial/eas/configure-development-build/) for your platform. For example, if you're building for the iOS simulator, run:
-
-```
-eas build --platform ios --profile ios-simulator
 ```
 
 :::
@@ -137,7 +141,7 @@ There are several ways to present a paywall in Expo, each with different use cas
 
 ### Testing your app
 
-To test, we'll use EAS to build the app for the simulator. You'll need to sign up at expo.dev and use the account below.
+To test, we'll use EAS to build the app for the simulator. You'll need to sign up at [expo.dev](https://expo.dev) and use the account below.
 
 For more information about EAS, see the [EAS docs](https://docs.expo.dev/tutorial/eas/introduction/).
 
@@ -164,8 +168,6 @@ eas init
 ```
 
 The command will ask you to choose the platforms you want to build for.
-
-You can read more about
 
 #### Testing on iOS simulator
 
@@ -200,38 +202,24 @@ Your `eas.json` file might look like this:
 }
 ```
 
-`eas build --platform ios --profile ios-simulator`
+Next, build the app for the simulator:
 
-Building creates a container app with your installed dependencies. Once the build completes and you run it on the device, the app will hot reload with your local changes during development
+```
+eas build --platform ios --profile ios-simulator
+```
 
-Enter bundle ID, matching RevenueCat config and App Store Connect
+Building creates a container app with your installed dependencies. Once the build completes and you run it on the device (or simulator, in this case), the app will hot reload with your local changes during development.
 
-Open in simulator
+Enter your app's bundle ID, matching your RevenueCat config and App Store Connect. Once the build completes, Expo will ask if you want to open the app in the simulator. Choose yes, and it'll launch the simulator with your app.
 
-`npx expo start`, choose the server in the iOS simulator
+After your app is running, you'll need to start the Expo server:
+
+```
+npx expo start
+```
+
+Finally, choose the local development server in the iOS simulator.
 
 ## Expo Go
 
 Expo Go is not supported at this time.
-
-# OLD CONTENT
-
-## I don't know if it's relevant anymore
-
-`react-native-purchases` works with with any Expo project when using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). A development build helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. It also enables you to only write JavaScript/TypeScript while letting Expo tools and services take care of everything else. The Android and iOS apps are built using Expo's build service and generate development and production binaries for testing and releasing.
-
-As of mid 2021, projects created with Expo now support in-app payments and are compatible with `react-native-purchases`. Running `npx expo install react-native-purchases` is all that needs to be done before you can start implementing RevenueCat into your app.
-
-Note: Expo's docs state that in-app purchases will only work on real Android and iOS devices which can make debugging more difficult. You can view the RevenueCat debug logs on Android with LogCat and iOS with Console.app.
-
-For more information, see our blog post [here](https://www.revenuecat.com/blog/in-app-puchase-expo-managed-workflow/).
-
-#### Bare workflow
-
-If you are using [bare workflow](https://docs.expo.dev/bare/overview/) (that is, your project is created using `react-native init`), [install `expo`](https://docs.expo.dev/bare/installing-expo-modules/) into your project and [leverage Expo CLI](https://docs.expo.dev/bare/using-expo-cli/) to use Expo tooling and services.
-
-The bare workflow gives developers complete native control but also allows the use of Expo libraries and services. The bare workflow is similar to a project you would get from `npx react-native init`.
-
-If you're planning on ejecting from Expo to use the bare workflow, upgrade your Expo version first, _then_ eject. It'll save you a whole lot of hassle.
-
-Get started with the bare workflow [here](https://docs.expo.dev/bare/overview/).

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -121,7 +121,7 @@ import expoContent from "!!raw-loader!@site/code_blocks/getting-started/getting-
 
 RevenueCat is the single source of truth for your customer's subscription status across all platforms. Learn more about the different ways to identify your customers to RevenueCat [here](/docs/customers/identifying-customers).
 
-Then, [check the customer's subscription status](/docs/customers/customer-info) by fetching the [CustomerInfo object](/docs/customers/customer-info#:~:text=CustomerInfo%20Reference):
+Then, [check the customer's subscription status](/docs/customers/customer-info) by fetching the [CustomerInfo object](/docs/customers/customer-info#reference):
 
 import content6 from "!!raw-loader!@site/code_blocks/customers/customer-info_6.js";
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -121,7 +121,7 @@ import expoContent from "!!raw-loader!@site/code_blocks/getting-started/getting-
 
 RevenueCat is the single source of truth for your customer's subscription status across all platforms. Learn more about the different ways to identify your customers to RevenueCat [here](/customers/identifying-customers).
 
-Then, [check the customer's subscription status](/docs/customers/customer-info) by fetching the [CustomerInfo object](/docs/customers/customer-info#reference):
+Then, [check the customer's subscription status](/customers/customer-info) by fetching the [CustomerInfo object](/customers/customer-info#reference):
 
 import content6 from "!!raw-loader!@site/code_blocks/customers/customer-info_6.js";
 

--- a/docs/getting-started/installation/reactnative.mdx
+++ b/docs/getting-started/installation/reactnative.mdx
@@ -15,9 +15,10 @@ RevenueCat provides a backend and a wrapper around StoreKit and Google Play Bill
 
 Make sure that the deployment target for iOS is at least 13.4 and Android is at least 6.0 (API 23) [as defined here](https://github.com/facebook/react-native#-requirements).
 
-### Option 1: React-Native package
+### React Native package
 
-Purchases for React-Native can be installed either via npm or yarn.
+Purchases for React Native can be installed either via npm or yarn.
+
 We recommend using the latest version of React Native, or making sure that the version is at least greater than 0.64.
 
 #### Option 1.1: Using auto-linking
@@ -51,25 +52,11 @@ import reactNativeShellContent from "!!raw-loader!@site/code_blocks/getting-star
   tabs={[{ type: "shell", content: reactNativeShellContent, name: "Shell" }]}
 />
 
-### Option 2: Using Expo
+### Using Expo
 
-`react-native-purchases` works with with any Expo project when using a [development build](https://docs.expo.dev/workflow/overview/#development-builds). A development build helps you iterate as quickly as possible and provides a more flexible, reliable, and complete development environment. It also enables you to only write JavaScript/TypeScript while letting Expo tools and services take care of everything else. The Android and iOS apps are built using Expo's build service and generate development and production binaries for testing and releasing.
+Use Expo to rapidly iterate on your app by using JavaScript/TypeScript exclusively, while letting Expo take care of everything else.
 
-As of mid 2021, projects created with Expo now support in-app payments and are compatible with `react-native-purchases`. Running `npx expo install react-native-purchases` is all that needs to be done before you can start implementing RevenueCat into your app.
-
-Note: Expo's docs state that in-app purchases will only work on real Android and iOS devices which can make debugging more difficult. You can view the RevenueCat debug logs on Android with LogCat and iOS with Console.app.
-
-For more information, see our blog post [here](https://www.revenuecat.com/blog/in-app-puchase-expo-managed-workflow/).
-
-#### Bare workflow
-
-If you are using [bare workflow](https://docs.expo.dev/bare/overview/) (that is, your project is created using `react-native init`), [install `expo`](https://docs.expo.dev/bare/installing-expo-modules/) into your project and [leverage Expo CLI](https://docs.expo.dev/bare/using-expo-cli/) to use Expo tooling and services.
-
-The bare workflow gives developers complete native control but also allows the use of Expo libraries and services. The bare workflow is similar to a project you would get from `npx react-native init`.
-
-If you're planning on ejecting from Expo to use the bare workflow, upgrade your Expo version first, _then_ eject. It'll save you a whole lot of hassle.
-
-Get started with the bare workflow [here](https://docs.expo.dev/bare/overview/).
+See [Using RevenueCat with Expo](/getting-started/installation/expo) to get started.
 
 ### Set the correct launchMode for Android
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -83,6 +83,7 @@ const mobileSDKCategory = Category({
         Page({ slug: "ios" }),
         Page({ slug: "android" }),
         Page({ slug: "reactnative" }),
+        Page({ slug: "expo" }),
         Page({ slug: "flutter" }),
         Page({ slug: "kotlin-multiplatform" }),
         Page({ slug: "capacitor" }),


### PR DESCRIPTION
## Motivation / Description

Our Expo docs have been outdated for a while, this attempts to correct and provide much more specific guidance

## Changes introduced

- new Expo doc under the Installation section
- React Native installation docs link out now

## Linear ticket (if any)

## Additional comments
