### PR TITLE
fix store faqs titles

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -432,7 +432,7 @@ const platformResourcesCategory = Category({
           slug: "/platform-resources/server-notifications/apple-server-notifications",
         }),
         SubCategory({
-          label: "FAQs",
+          label: "Apple App Store FAQs",
           itemsPathPrefix: "platform-resources/apple-platform-resources/",
           items: [
             Page({ slug: "app-store-small-business-program" }),
@@ -466,7 +466,7 @@ const platformResourcesCategory = Category({
           slug: "/platform-resources/server-notifications/google-server-notifications",
         }),
         SubCategory({
-          label: "FAQs",
+          label: "Google Play Store FAQs",
           itemsPathPrefix: "platform-resources/google-platform-resources/",
           items: [
             Page({ slug: "google-play-pass" }),
@@ -494,7 +494,7 @@ const platformResourcesCategory = Category({
           slug: "/platform-resources/server-notifications/amazon-server-notifications",
         }),
         SubCategory({
-          label: "FAQs",
+          label: "Amazon Appstore FAQs",
           itemsPathPrefix: "platform-resources/amazon-platform-resources/",
           items: [Page({ slug: "amazon-small-business-accelerator-program" })],
           index: {

--- a/src/sidebars/sidebar-utils.js
+++ b/src/sidebars/sidebar-utils.js
@@ -46,7 +46,7 @@ const SubCategory = ({ label, slug, itemsPathPrefix, items, index }) => ({
     link: {
       type: "generated-index",
       title: index.title,
-      slug: index.link + "-index",
+      slug: index.link,
       ...(index.description && { description: index.description }),
     },
   }),

--- a/src/sidebars/sidebar-utils.js
+++ b/src/sidebars/sidebar-utils.js
@@ -46,7 +46,7 @@ const SubCategory = ({ label, slug, itemsPathPrefix, items, index }) => ({
     link: {
       type: "generated-index",
       title: index.title,
-      slug: index.link,
+      slug: index.link + "-index",
       ...(index.description && { description: index.description }),
     },
   }),


### PR DESCRIPTION
## Motivation / Description

The store FAQ pages all had the same "Amazon Appstore FAQs" title:

![image](https://github.com/user-attachments/assets/63e3b643-4a79-4e43-96b1-5d26cfcab2a8)
![image](https://github.com/user-attachments/assets/f24319fe-7212-4f17-b726-fd56ef266955)
![image](https://github.com/user-attachments/assets/ea338a73-20a9-4ecf-ab03-fff4e455e996)

This is because they all had the same label in the sidebar and these pages are auto-generated by the sidebar. This fixes this by changing the titles of the FAQ pages to all be unique:

![image](https://github.com/user-attachments/assets/e6e927b2-35c9-4279-bd8a-c22e79b0e5d5)

Now the pages have the correct titles:

![image](https://github.com/user-attachments/assets/47e51b38-63f1-4504-ab0d-72728efc3a8c)
![image](https://github.com/user-attachments/assets/ae7c0bfb-1656-4676-95e6-cc75cd080472)
![image](https://github.com/user-attachments/assets/43f6eac7-b30c-46ef-a3d3-8e0c6f071c07)

~~Since I was already in the code, I also fixed the slug to say /docs/store-configuration/amazon/faqs instead of /docs/store-configuration/amazon/faqs-index. @codykerns was there a specific reason you were generating the FAQ pages on faqs-index?~~ nvm a bunch of links rely on generated indexes having -index so I undid this change.

## Changes introduced

Change labels of FAQ pages in sidebar to be unique

## Linear ticket (if any)

## Additional comments
