### PR TITLE
Add missing reserved customer attributes

### DIFF
--- a/docs/customers/customer-attributes.mdx
+++ b/docs/customers/customer-attributes.mdx
@@ -103,42 +103,42 @@ Attribute keys beginning with `$` are reserved for RevenueCat. The current list 
 
 #### General
 
-| Key                              | Description                                                                                                                                                     |
-| :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `$displayName`                   | Name that should be used to reference the user                                                                                                                  |
-| `$apnsTokens`                    | Apple push notification tokens for the user.                                                                                                                    |
-| `$fcmTokens`                     | Google push notification tokens for the user.                                                                                                                   |
-| `$attConsentStatus`              | Apple App Tracking Transparency consent status for the user.                                                                                                    |
-| `$clevertapId `                  | Clever Tap ID for the user.                                                                                                                                     |
-| `$idfa`                          | iOS advertising identifier UUID.                                                                                                                                |
-| `$idfv`                          | iOS vendor identifier UUID.                                                                                                                                     |
-| `$gpsAdId`                       | The advertising ID that is provided by Google Play services.                                                                                                    |
-| `$amazonAdId`                    | Amazon Advertising ID.                                                                                                                                          |
-| `$adjustId`                      | The unique Adjust identifier for the user.                                                                                                                      |
-| `$amplitudeDeviceId`             | The Amplitude Device ID.                                                                                                                                        |
-| `$amplitudeUserId`               | The Amplitude User ID.                                                                                                                                          |
-| `$appsflyerId`                   | Appsflyer Id. The unique Appsflyer identifier for the user.                                                                                                     |
-| `$brazeAliasName`                | The Braze 'alias_name' in User Alias Object.                                                                                                                    |
-| `$brazeAliasLabel`               | The Braze 'alias_label' in User Alias Object.                                                                                                                   |
-| `$clevertapId`                   | The CleverTap ID for the user.                                                                                                                                  |
-| `$fbAnonId`                      | The Facebook Anonymous ID for the user.                                                                                                                         |
-| `$attConsentStatus`              | Apple App Tracking Transparency consent status for the user.                                                                                                    |
-| `$mparticleId`                   | The unique mParticle user identifier (mpid).                                                                                                                    |
-| `$onesignalId`                   | The OneSignal Player Id for the user.                                                                                                                           |
-| `$airshipChannelId`              | The Airship channel ID for the user.                                                                                                                            |
-| `$iterableUserId`                | The Iterable ID for the user.                                                                                                                                   |
-| `$iterableCampaignId`            | The Iterable campaign ID.                                                                                                                                       |
-| `$iterableTemplateId`            | The Iterable template ID.                                                                                                                                       |
-| `$firebaseAppInstanceId`         | The Firebase instance identifier.                                                                                                                               |
-| `$mixpanelDistinctId`            | The Mixpanel user identifier.                                                                                                                                   |
-| `$kochavaDeviceId`               | The unique Kochava device identifier.                                                                                                                           |
-| `$ip`                            | The IP address of the device.                                                                                                                                   |
-| `$email`                         | Email address for the user.                                                                                                                                     |
-| `$phoneNumber`                   | Phone number for the user.                                                                                                                                      |
-| `$posthogUserId`                 | The PostHog User ID                                                                                                                                             |
-| `$deviceVersion`                 | Device, platform and version information.                                                                                                                       |
-| `$appleRefundHandlingPreference` | The [App Store refund preference](/platform-resources/apple-platform-resources/handling-refund-requests#overriding-refund-preference) to override for the user. |
-| `$customerioId`                  | The Customer.io person's identifier (`id`)                                                                                                                      |
+| Key                              | Description                                                                                                                                                                                 |
+| :------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------                             |
+| `$displayName`                   | Name that should be used to reference the user                                                                                                                                              |
+| `$apnsTokens`                    | Apple push notification tokens for the user.                                                                                                                                                |
+| `$fcmTokens`                     | Google push notification tokens for the user.                                                                                                                                               |
+| `$attConsentStatus`              | Apple App Tracking Transparency consent status for the user.                                                                                                                                |
+| `$clevertapId `                  | Clever Tap ID for the user.                                                                                                                                                                 |
+| `$idfa`                          | iOS advertising identifier UUID.                                                                                                                                                            |
+| `$idfv`                          | iOS vendor identifier UUID.                                                                                                                                                                 |
+| `$gpsAdId`                       | The advertising ID that is provided by Google Play services.                                                                                                                                |
+| `$androidId`                     | The advertising ID that is provided by Google Play services. This ID is deprecated, read more [here](/customers/customer-attributes#reserved-attributes:~:text=ANDROID%20ID%20DEPRECATION). |
+| `$amazonAdId`                    | Amazon Advertising ID.                                                                                                                                                                      |
+| `$adjustId`                      | The unique Adjust identifier for the user.                                                                                                                                                  |
+| `$amplitudeDeviceId`             | The Amplitude Device ID.                                                                                                                                                                    |
+| `$amplitudeUserId`               | The Amplitude User ID.                                                                                                                                                                      |
+| `$appsflyerId`                   | Appsflyer Id. The unique Appsflyer identifier for the user.                                                                                                                                 |
+| `$brazeAliasName`                | The Braze 'alias_name' in User Alias Object.                                                                                                                                                |
+| `$brazeAliasLabel`               | The Braze 'alias_label' in User Alias Object.                                                                                                                                               |
+| `$fbAnonId`                      | The Facebook Anonymous ID for the user.                                                                                                                                                     |
+| `$mparticleId`                   | The unique mParticle user identifier (mpid).                                                                                                                                                |
+| `$onesignalId`                   | The OneSignal Player Id for the user.                                                                                                                                                       |
+| `$airshipChannelId`              | The Airship channel ID for the user.                                                                                                                                                        |
+| `$iterableUserId`                | The Iterable ID for the user.                                                                                                                                                               |
+| `$iterableCampaignId`            | The Iterable campaign ID.                                                                                                                                                                   |
+| `$iterableTemplateId`            | The Iterable template ID.                                                                                                                                                                   |
+| `$firebaseAppInstanceId`         | The Firebase instance identifier.                                                                                                                                                           |
+| `$mixpanelDistinctId`            | The Mixpanel user identifier.                                                                                                                                                               |
+| `$kochavaDeviceId`               | The unique Kochava device identifier.                                                                                                                                                       |
+| `$tenjinId`.                     | The Tenjin identifier.                                                                                                                                                                      |
+| `$ip`                            | The IP address of the device.                                                                                                                                                               |
+| `$email`                         | Email address for the user.                                                                                                                                                                 |
+| `$phoneNumber`                   | Phone number for the user.                                                                                                                                                                  |
+| `$posthogUserId`                 | The PostHog User ID                                                                                                                                                                         |
+| `$deviceVersion`                 | Device, platform and version information.                                                                                                                                                   |
+| `$appleRefundHandlingPreference` | The [App Store refund preference](/platform-resources/apple-platform-resources/handling-refund-requests#overriding-refund-preference) to override for the user.                             |
+| `$customerioId`                  | The Customer.io person's identifier (`id`)                                                                                                                                                  |
 
 :::warning attConsentStatus is populated regardless of requesting any permission
 
@@ -191,6 +191,7 @@ Therefore, Google's Advertising ID acts as the primary device identifier for And
 | `$clevertapId`           | [CleverTap](https://clevertap.com/) user identifier                                           |
 | `$airshipChannelId`      | [Airship](https://www.airship.com/) channel identifier                                        |
 | `$kochavaDeviceId`       | [Kochava](https://www.kochava.com/) device identifier                                         |
+| `$tenjinId`.             | The Tenjin identifier.                                                                        |
 | `$posthogUserId`         | [PostHog](https://posthog.com) user identifier                                                |
 | `$customerioId`          | [Customer.io](https://customer.io) person identifier                                          |
 


### PR DESCRIPTION
## Motivation / Description

We were missing a $androidId and $tenjinId from our list of reserved customer attributes, so I added them in. Also removed a couple of attributes that were duplicated in the list.

## Changes introduced

## Linear ticket (if any)

## Additional comments
