### PR TITLE
Document SK Bug with Purchase Sheets Not Appearing on iOS 18.2.X

### DIFF
--- a/docs/known-store-issues/storekit.md
+++ b/docs/known-store-issues/storekit.md
@@ -12,6 +12,7 @@ This section covers known issues specifically related to Apple's StoreKit framew
 
 ## Resolved Issues
 - [iOS 18.3.1-18.5 Canceled State After Successful Purchase](storekit/ios-18-4-canceled-state-after-successful-purchase)
+- [iOS 18.2.-18.2.1 Purchase Sheet May Fail to Appear](storekit/ios-18-2-purchase-sheet-may-fail-to-appear)
 
 ## General StoreKit Troubleshooting
 

--- a/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
+++ b/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
@@ -2,7 +2,6 @@
 title: iOS 18.2.X Purchase Sheet May Fail to Appear
 ---
 
-# iOS 18.2.X Purchase Sheet May Fail to Appear
 
 ## Resolved
 Apple has resolved this issue, and it is not present in iOS 18.3 and above. The issue is still present in iOS 18.2.X. We are keeping this page for historical reference.

--- a/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
+++ b/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
@@ -40,4 +40,4 @@ If your app manifests the issue but these workarounds do not apply to your view 
 
 ## Status
 
-✅ **Resolved** - Apple has resolved this issue in iOS 18.3. No further action is required for new app releases. If users enounter this bug, instruct them to upgrade their iOS version and try again.
+✅ **Resolved** - Apple has resolved this issue in iOS 18.3. No further action is required for new app releases. If users encounter this bug, instruct them to upgrade their iOS version and try again.

--- a/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
+++ b/docs/known-store-issues/storekit/ios-18-2-purchase-sheet-may-fail-to-appear.md
@@ -1,0 +1,43 @@
+---
+title: iOS 18.2.X Purchase Sheet May Fail to Appear
+---
+
+# iOS 18.2.X Purchase Sheet May Fail to Appear
+
+## Resolved
+Apple has resolved this issue, and it is not present in iOS 18.3 and above. The issue is still present in iOS 18.2.X. We are keeping this page for historical reference.
+
+## Issue Description
+
+iOS 18.2 introduced a bug which prevents the payment sheet from being displayed if the current scene's key window root view controller is not a part of the view hierarchy, thus impacting the RevenueCat SDK's ability to display the purchase sheet to end users.
+
+## Affected Versions
+
+- iOS 18.2
+- iOS 18.2.1
+
+## Symptoms
+- Calling any of RevenueCat's `purchase` functions on iOS 18.2.X will fail to present a purchase sheet.
+- StoreKit prints the following error message in the console when the purchase sheet fails to appear: `Could not get confirmation scene ID for`
+
+## Workarounds
+
+This bug can occur if your app is currently presenting a modal view controller with:
+
+- `modalPresentationStyle = .fullScreen` on UIKit
+- `fullScreenCover(isPresented:onDismiss:content:)` in SwiftUI
+
+To work around the issue:
+
+- Use `modalPresentationStyle = .overFullScreen` on UIKit
+- Use `sheet(isPresented:onDismiss:content:)` on SwiftUI
+
+If your app manifests the issue but these workarounds do not apply to your view structure, make sure your root view controller is part of the view hierarchy when initiating a purchase.
+
+## Impact on App Store Review
+
+**This bug should not cause app rejections**, since App Reviewers should no longer be testing on iOS 18.2.X.
+
+## Status
+
+✅ **Resolved** - Apple has resolved this issue in iOS 18.3. No further action is required for new app releases. If users enounter this bug, instruct them to upgrade their iOS version and try again.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -818,6 +818,7 @@ const knownStoreIssuesCategory = Category({
       items: [
         Page({ slug: "ios-18-4-simulator-fails-to-load-products" }),
         Page({ slug: "ios-18-4-canceled-state-after-successful-purchase" }),
+        Page({ slug: "ios-18-2-purchase-sheet-may-fail-to-appear" }),
       ],
     }),
   ],


### PR DESCRIPTION
## Changes introduced
- Document the StoreKit bug that causes purchase sheets to not appear on iOS 18.2.X