### PR TITLE
added limitation on mixed checkout sessions

### DIFF
--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -44,6 +44,7 @@ Web Billing currently has a number of known limitations. Most notably:
 - There is no support for our Paywall templates yet.
 - There is no support for translated email (these are currently only sent in English, regardless of the selected locale).
 - We do not collect the customer's name, shipping address or full billing address. Consequently, Web Billing cannot be used in India and in other countries that have this requirement.
+- Mixed checkout sessions (containing both subscriptions and one-time purchases) are not supported. Only the subscription will be tracked in RevenueCat.
 
 ## Web Billing vs. Stripe Billing integration
 


### PR DESCRIPTION
## Motivation / Description

Customer asked about mixed checkout (otp with subscriptions) and why their otp were not showing in RevenueCat.

[Slack here](https://revenuecat.slack.com/archives/C018CHK6A6R/p1749146951183789) and [ticket here](https://revenuecat.zendesk.com/agent/tickets/59394)

## Changes introduced

Added a new limitation entry

## Linear ticket (if any)
n/a

## Additional comments
n/a

## Visuals
<img width="834" alt="Screenshot 2025-06-06 at 10 33 48" src="https://github.com/user-attachments/assets/f91f0795-b264-418b-ae5a-74d4f960ae8c" />

