### PR TITLE
update expo docs to mention Preview API

### DIFF
--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -254,4 +254,10 @@ npx expo start
 
 ## Expo Go
 
-[Expo Go](https://expo.dev/go) is a sandbox that allows you to rapidly prototype your app. However, Expo Go does not run native code, so testing in-app purchases is not supported. Once you've added RevenueCat's SDKs to your app, please use a [development build](/getting-started/installation/expo#create-an-expo-development-build) for testing.
+[Expo Go](https://expo.dev/go) is a sandbox that allows you to rapidly prototype your app. While it doesn’t support running custom native code—such as the native modules required for in-app purchases—`react-native-purchases` includes a built-in **Preview API Mode** specifically for Expo Go.
+
+When your app runs inside Expo Go, `react-native-purchases` automatically detects the environment and replaces native calls with JavaScript-level mock APIs. This allows your app to load and execute all subscription-related logic without errors, even though real purchases will not function in this mode.
+
+This means you can still preview subscription UIs, test integration flows, and continue development without needing to build a custom development client immediately.
+
+However, to fully test in-app purchases and access real RevenueCat functionality, you must use a [development build](/getting-started/installation/expo#create-an-expo-development-build).


### PR DESCRIPTION
## Motivation / Description

Expands on the Expo docs to mention that react-native-purchases can now be installed on apps running in Expo Go and that they make use of the Preview API Mode