### PR TITLE
Update non-subscriptions.mdx

### DIFF
--- a/docs/platform-resources/non-subscriptions.mdx
+++ b/docs/platform-resources/non-subscriptions.mdx
@@ -26,9 +26,9 @@ Although RevenueCat is primarily used to handle subscription purchases, our SDK 
 
 :::warning Google Play Store IAPs
 
-Google Play Store does not provide an option to mark IAPs as consumable or non-consumable. RevenueCat's SDK will consume all Android IAPs upon purchase.
+Non-consumable support is supported in Android SDK version 7.11.0 and up. 
 
-To replicate the behavior of a non-consumable IAP for Android users, you must ensure your user will not be offered the IAP after the initial purchase. Failure to do so will enable the user to re-purchase the IAP.
+In Android SDK version 7.10.1 and below all Android IAPs will be consumed upon purchase. To replicate the behavior of a non-consumable IAP for Android users, you must ensure your user will not be offered the IAP after the initial purchase. Failure to do so will enable the user to re-purchase the IAP.
 :::
 
 ## Entitlements


### PR DESCRIPTION
## Motivation / Description
There is a callout [here](https://www.revenuecat.com/docs/getting-started/entitlements/android-products#add-non-consumable-products:~:text=Non%2Dconsumable%20support%20is%20supported%20in%20Android%20SDK%20version%207.11.0%20and%20up.%20In%20previous%20versions%2C%20the%20SDK%20will%20always%20consume%20the%20purchase) that is easy to miss if just looking at the non-subscription doc so I added it there for more visibility

## Changes introduced

## Linear ticket (if any)

## Additional comments
