### PR TITLE
Added Expo blog post callout

### DIFF
--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -8,7 +8,7 @@ hidden: false
 :::success Welcome Bolt Hackathon participants!
 Integrating RevenueCat's in-app purchase capabilities into your app requires you to [download your project](https://support.bolt.new/building/using-bolt/projects-files#download-projects) from Bolt. Then, open your project in an IDE of your choice (like [VSCode](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/)) and follow the instructions below.
 
-Best of luck with your [hackathon](https://hackathon.dev/) project, and [read more about adding subscriptions to a Bolt-generated Expo app here](https://www.revenuecat.com/blog/engineering/how-to-add-in-app-purchases-to-your-bolt-generated-expo-app/)!
+Best of luck with your [hackathon](https://hackathon.dev/) project, and [read more about adding subscriptions to a Bolt-generated Expo app here](https://www.revenuecat.com/blog/engineering/how-to-add-in-app-purchases-to-your-bolt-generated-expo-app/).
 :::
 
 ## What is RevenueCat?

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -8,7 +8,7 @@ hidden: false
 :::success Welcome Bolt Hackathon participants!
 Integrating RevenueCat's in-app purchase capabilities into your app requires you to [download your project](https://support.bolt.new/building/using-bolt/projects-files#download-projects) from Bolt. Then, open your project in an IDE of your choice (like [VSCode](https://code.visualstudio.com/) or [Cursor](https://www.cursor.com/)) and follow the instructions below.
 
-Best of luck with your [hackathon](https://hackathon.dev/) project!
+Best of luck with your [hackathon](https://hackathon.dev/) project, and [read more about adding subscriptions to a Bolt-generated Expo app here](https://www.revenuecat.com/blog/engineering/how-to-add-in-app-purchases-to-your-bolt-generated-expo-app/)!
 :::
 
 ## What is RevenueCat?


### PR DESCRIPTION
The callout now links to https://www.revenuecat.com/blog/engineering/how-to-add-in-app-purchases-to-your-bolt-generated-expo-app/