### PR TITLE
List out statuses in customer lists

### DIFF
--- a/docs/dashboard-and-metrics/customer-lists.md
+++ b/docs/dashboard-and-metrics/customer-lists.md
@@ -164,6 +164,24 @@ See the table below for all filters you can apply to your lists.
 Selecting any date filters will apply to the start of the day. For example, `2021-01-01` will be `2021-01-01T00:00:00` under the hood.
 :::
 
+### Status Filter
+
+The Status filter provides these options to refine your customer list:
+
+- **Active**: The customer has an active subscription.
+- **Free Trial**: The customer currently has an active trial subscription.
+- **Intro Period**: The customer’s subscription is currently in a discounted introductory (non-free) period.
+- **Promotional**: The customer has a [promotional entitlement](/dashboard-and-metrics/customer-history/promotionals).
+- **Billing Issue**: The customer's subscription is experiencing a billing retry period.
+- **Billing Issue Trial**: The customer is in a trial period experiencing billing issues.
+- **Cancelled**: The customer has cancelled their subscription.
+- **Cancelled Trial**: The customer has cancelled their trial subscription.
+- **Expired**: The customer's subscription has ended and is no longer active.
+
+:::info
+Applying any status filter will limit the customer list to customers who have made at least one purchase.
+:::
+
 ## Exporting Data
 
 The complete list of customers in a list can be exported as a .csv file. Exports are processed in the background, and you'll receive an email with a link to download the file. Emails are sent to the logged in account that requested the export. The download links are shareable and available for 30 days.

--- a/docs/dashboard-and-metrics/customer-lists.md
+++ b/docs/dashboard-and-metrics/customer-lists.md
@@ -182,6 +182,12 @@ The Status filter provides these options to refine your customer list:
 Applying any status filter will limit the customer list to customers who have made at least one purchase.
 :::
 
+:::info
+If a customer has more than one subscription, the status filter applies only to the customer's latest transaction.
+
+Additionally, promotional status is ranked lower than other statuses, regardless of whether the promotional purchase is the latest transaction.
+:::
+
 ## Exporting Data
 
 The complete list of customers in a list can be exported as a .csv file. Exports are processed in the background, and you'll receive an email with a link to download the file. Emails are sent to the logged in account that requested the export. The download links are shareable and available for 30 days.


### PR DESCRIPTION
## Motivation / Description

Added a section that documents the statuses available in customer lists and includes a note about how statuses filter only on customers who have made purchases.

## Changes introduced

## Linear ticket (if any)

## Additional comments
