### PR TITLE
Add Flutter web callout in installation doc

### DIFF
--- a/code_blocks/getting-started/installation/flutter_1.yaml
+++ b/code_blocks/getting-started/installation/flutter_1.yaml
@@ -1,2 +1,2 @@
 dependencies:
-  purchases_flutter: <latest version>
+  purchases_flutter: <latest version> // or 9.0.0-beta.3 for Flutter Web

--- a/docs/getting-started/installation/flutter.mdx
+++ b/docs/getting-started/installation/flutter.mdx
@@ -5,6 +5,12 @@ excerpt: Instructions for installing Purchases SDK for Flutter
 hidden: false
 ---
 
+:::success Flutter Web Support in Beta
+We're excited to announce that Flutter Web support is now in beta! This means you can now use RevenueCat to manage subscriptions across your Flutter web, mobile, and desktop apps.
+
+Learn more about the Flutter Web beta [here](https://www.revenuecat.com/blog/engineering/flutter-sdk-web-support-beta/).
+:::
+
 ## What is RevenueCat?
 
 RevenueCat provides a backend and a wrapper around StoreKit and Google Play Billing to make implementing in-app purchases and subscriptions easy. With our SDK, you can build and manage your app business on any platform without having to maintain IAP infrastructure. You can read more about [how RevenueCat fits into your app](https://www.revenuecat.com/blog/growth/where-does-revenuecat-fit-in-your-app/) or you can [sign up free](https://app.revenuecat.com/signup) to start building.


### PR DESCRIPTION
- Added note in flutter_1.yaml to specify using purchases_flutter version 9.0.0-beta.3 for Flutter Web.
- Introduced a success callout in flutter.mdx announcing Flutter Web support in beta and linking to further information.

<img width="833" alt="Screenshot 2025-06-19 at 2 21 49 PM" src="https://github.com/user-attachments/assets/af0128fd-2979-4fd1-b797-ebf218c0fefd" />