### PR TITLE
[Known Issues] - Xcode 26 URLSessionConfiguration Crash Workaround

### DIFF
--- a/code_blocks/known-issues/xcode-26-crash.swift
+++ b/code_blocks/known-issues/xcode-26-crash.swift
@@ -1,0 +1,22 @@
+// App Initialization
+import Networking
+
+@main
+struct MyApp: App {
+    init() {
+        nw_tls_create_options()
+    }
+}
+
+// AppDelegate Initialization
+import Networking
+
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions _: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+
+        nw_tls_create_options()
+        Purchases.configure(withAPIKey: "redacted")
+
+        return true
+    }
+}

--- a/docs/known-store-issues/xcode-26.md
+++ b/docs/known-store-issues/xcode-26.md
@@ -1,0 +1,14 @@
+---
+title: Xcode 26 beta Known Issues
+sidebar_label: Xcode 26 beta
+---
+
+This section covers known issues specifically related to the newest Xcode version (Xcode 26 beta) that may affect your RevenueCat integration.
+
+## Current Issues
+
+- [URLSessionConfiguration Crash](xcode-26/app-crash-urlsessionconfiguration.mdx)
+
+---
+
+_Issues are documented as they're discovered and verified._

--- a/docs/known-store-issues/xcode-26/app-crash-urlsessionconfiguration.mdx
+++ b/docs/known-store-issues/xcode-26/app-crash-urlsessionconfiguration.mdx
@@ -1,0 +1,44 @@
+---
+title: URLSessionConfiguration Crash
+sidebar_label: URLSessionConfiguration Crash
+---
+
+## Issue Description
+
+Xcode 26 beta introduces a bug that may cause your app to crash when integrating multiple libraries—such as RevenueCat's SDK—that utilize `URLSessionConfiguration`. This issue occurs when running the app on iOS 26 simulators.
+
+You can find more information in the following [Apple Developer Forum thread](https://developer.apple.com/forums/thread/787365).
+
+## Affected Versions
+
+- Xcode 26 beta
+- iOS 26 simulators
+
+## Symptoms
+
+- Your project includes libraries in addition to RevenueCat.
+- The app crashes immediately upon launch when using Xcode 26 beta with iOS 26 simulators.
+
+## Workarounds
+
+While awaiting a fix from Apple, a temporary workaround is to initiate a networking call early during app initialization. This appears to prevent the crash.
+
+import crash from "@site/code_blocks/known-issues/xcode-26-crash.swift?raw";
+
+<RCCodeBlock
+  tabs={[
+    {
+      type: "swift",
+      title: "Networking call workaround",
+      content: crash,
+    },
+  ]}
+/>
+
+## Apple Feedback
+
+For ongoing updates, refer to [this Apple Developer Forum thread](https://developer.apple.com/forums/thread/787365). If the workaround above does not resolve the issue, please consider filing a bug report within that thread.
+
+## Status
+
+🕰️ Waiting on Apple's resolution.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -829,7 +829,7 @@ const guidesCategory = Category({
 
 const knownStoreIssuesCategory = Category({
   iconName: "heart-broken",
-  label: "Known Store Issues",
+  label: "Known Issues",
   itemsPathPrefix: "known-store-issues/",
   items: [
     SubCategory({
@@ -844,6 +844,12 @@ const knownStoreIssuesCategory = Category({
         }),
         Page({ slug: "ios-18-2-purchase-sheet-may-fail-to-appear" }),
       ],
+    }),
+    SubCategory({
+      label: "Xcode 26 beta",
+      slug: "xcode-26",
+      itemsPathPrefix: "xcode-26/",
+      items: [Page({ slug: "app-crash-urlsessionconfiguration" })],
     }),
   ],
 });


### PR DESCRIPTION
## Motivation / Description
Apps compiled using Xcode 26, along with iOS 26 simulators, may crash when libraries initialize `URLSessionConfiguration`.  More information about the crash can be found [here](https://developer.apple.com/forums/thread/787365).

Because there's a suggested workaround for this issue, I created the following document for devs to refer to. 

## Changes introduced
- Changed the `Known Store Issues` categories into `Known Issues` to include Xcode 26 beta issues.
- Added Xcode 26 beta issues sub-category and pages.
- Added a code snippet on how to implement the workaround.

## Linear ticket (if any)

## Additional comments
