### PR TITLE
Add duplicate experiment feature documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+### Core Commands
+
+- `yarn install` - Install dependencies
+- `yarn start` - Start development server on port 3030 with hot reload
+- `yarn build` - Build for production
+- `yarn serve` - Serve production build locally
+- `yarn clear` - Clear Docusaurus cache
+
+### Code Quality
+
+- `yarn format` - Format code with Prettier
+- `lefthook install` - Install pre-commit hooks (runs Prettier and typos checker)
+
+### Additional Tools
+
+- `typos` - Spell checker (install via `brew install typos-cli`)
+- Pre-commit hooks automatically run formatting and spell checking
+
+## High-Level Architecture
+
+### Documentation Site Structure
+
+This is a **Docusaurus-based documentation website** for RevenueCat, structured as a multi-platform SDK documentation hub covering iOS, Android, React Native, Flutter, Unity, Web, and more.
+
+### Key Architectural Components
+
+#### 1. Sidebar System (`sidebars.ts` + `src/sidebars/sidebar-utils.ts`)
+
+The heart of navigation uses TypeScript utilities to create structured documentation trees:
+
+- **Category**: Top-level sections with custom icons and colors
+- **SubCategory**: Collapsible sections that can have landing pages
+- **Page**: Individual documentation files
+- **Link**: Cross-references to pages in other categories
+
+Path construction is hierarchical: `Category.itemsPathPrefix` + `SubCategory.itemsPathPrefix` + `Page.slug`
+
+#### 2. Multiple Sidebar Configurations
+
+- `defaultSidebar`: Main implementation reference
+- `integrationsSidebar`: Events & integrations
+- `dataSidebar`: Charts, metrics, and data exports
+- `playbookSidebar`: Strategy guides
+
+#### 3. Code Snippet System
+
+Uses a global `RCCodeBlock` component for multi-language code examples:
+
+- Loads code from `/code_blocks/` directory using `?raw` imports
+- Supports tabbed interfaces for different platforms
+- **Important**: `.ts`/`.js` files must use `.txt` suffix for raw loading
+
+#### 4. Content Organization
+
+- `/docs/` - Main documentation content (MDX/Markdown)
+- `/code_blocks/` - Code examples organized by category
+- `/static/` - Images, icons, fonts, and other assets
+- `/openapi-spec/` - API specification files for REST API docs
+
+#### 5. Plugin Architecture
+
+Custom Docusaurus plugins for:
+
+- **Tailwind CSS integration** - PostCSS pipeline with custom theme
+- **Analytics** - Multiple tracking providers (Segment, HockeyStack, 6sense)
+- **Lightbox** - Image zoom functionality
+- **Raw file loading** - Webpack 5 asset/source for code blocks
+
+#### 6. Multi-API Documentation
+
+Uses Redocusaurus plugin to generate API docs from OpenAPI specs:
+
+- API v1, v2, v2-beta endpoints
+- External purchases API
+- Integrated into main navigation
+
+### Development Workflow Patterns
+
+#### Adding New Documentation
+
+1. Create `.md` or `.mdx` files in appropriate `/docs/` subdirectory
+2. Add to sidebar configuration in `sidebars.ts`
+3. Use `RCCodeBlock` for code examples, storing snippets in `/code_blocks/`
+
+#### Code Block Management
+
+- Store platform-specific examples in `/code_blocks/[category]/`
+- Use descriptive filenames with platform suffixes (e.g., `_1.swift`, `_2.kt`)
+- Load with `import content from "@site/code_blocks/path/file.ext?raw"`
+
+#### Sidebar Path Logic
+
+When adding pages, understand the path construction:
+
+```
+Category({ itemsPathPrefix: "getting-started/" })
+  → SubCategory({ itemsPathPrefix: "installation/" })
+    → Page({ slug: "ios" })
+= `/docs/getting-started/installation/ios`
+```
+
+### Key Configuration Files
+
+- `docusaurus.config.js` - Main site configuration with plugin setup
+- `sidebars.ts` - Navigation structure definition
+- `tailwind.config.js` - Styling configuration
+- `lefthook.yml` - Git hooks for code quality
+- `redocly.yaml` - API documentation configuration
+
+### Performance Optimizations
+
+- Uses Docusaurus Faster with experimental features enabled
+- Rspack bundler for faster builds
+- Lightning CSS minification
+- SWC for JavaScript processing
+- Persistent caching enabled
+
+This architecture prioritizes developer experience with hot reloading, comprehensive code quality tooling, and a flexible content organization system that scales across multiple product SDKs and platforms.

--- a/docs/tools/experiments-v1/configuring-experiments-v1.md
+++ b/docs/tools/experiments-v1/configuring-experiments-v1.md
@@ -26,6 +26,15 @@ Select **+ New** to create a new experiment from scratch.
 
 ![Creating a new experiment](/images/create_new_experiment_latest.png "Creating a new experiment")
 
+:::info Setting up Offering(s) for your treatment
+
+If you've not setup multiple Offerings before, you'll be prompted to do so now, since you'll need at least 2 available Offerings to run an experiment.
+
+The treatment Offering(s) represents the hypothesis you're looking to test with your experiment (e.g. higher or lower priced products, products with trials, etc).
+
+For App Store apps, we recommend setting up new products to test as a new Subscription Group so that customers who are offered those products through Experiments will see only that same set of products to select from their subscription settings.
+:::
+
 ### Duplicating an existing experiment
 
 You can also create a new experiment by duplicating the configuration of a previous experiment. This is useful when you want to run a similar test with slight modifications or test the same configuration on a different audience.
@@ -46,15 +55,6 @@ Duplicating is particularly useful when you want to:
 :::
 
 Regardless of which method you choose, you'll need to configure the experiment settings as described below.
-
-:::info Setting up Offering(s) for your treatment
-
-If you've not setup multiple Offerings before, you'll be prompted to do so now, since you'll need at least 2 available Offerings to run an experiment.
-
-The treatment Offering(s) represents the hypothesis you're looking to test with your experiment (e.g. higher or lower priced products, products with trials, etc).
-
-For App Store apps, we recommend setting up new products to test as a new Subscription Group so that customers who are offered those products through Experiments will see only that same set of products to select from their subscription settings.
-:::
 
 ## Required fields
 

--- a/docs/tools/experiments-v1/configuring-experiments-v1.md
+++ b/docs/tools/experiments-v1/configuring-experiments-v1.md
@@ -18,9 +18,34 @@ First, navigate to your Project. Then, click on **Experiments** in the **Monetiz
 
 ![Navigate](/images/c7867f1-Screenshot_2024-01-29_at_10.45.53_AM_17e0a4c0a6bcff7244ee397897c06ca4.png "Navigate")
 
-Select **+ New** to create a new experiment.
+You have two options for creating a new experiment:
+
+### Creating a new experiment from scratch
+
+Select **+ New** to create a new experiment from scratch.
 
 ![Creating a new experiment](/images/create_new_experiment_latest.png "Creating a new experiment")
+
+### Duplicating an existing experiment
+
+You can also create a new experiment by duplicating the configuration of a previous experiment. This is useful when you want to run a similar test with slight modifications or test the same configuration on a different audience.
+
+To duplicate an experiment:
+
+1. Find the experiment you want to duplicate in your experiments list
+2. Click on the **context menu** (three dots) next to the experiment
+3. Select **Duplicate** from the menu
+4. A new experiment will be created with the same configuration as the original
+5. You can then modify any settings as needed before starting the duplicated experiment
+
+:::tip When to use duplicate
+Duplicating is particularly useful when you want to:
+- Re-run a successful experiment on a different audience or time period
+- Test slight variations of a previous experiment configuration
+- Quickly set up similar experiments without manually configuring all settings again
+:::
+
+Regardless of which method you choose, you'll need to configure the experiment settings as described below.
 
 :::info Setting up Offering(s) for your treatment
 
@@ -151,6 +176,7 @@ When an experiment is running, only the percent of new customers to enroll can b
 | Can I run an experiment targeting different app versions for each app in my project? | No, at this time we don't support setting up an experiment in this way. However, you can certainly create unique experiments for each app, and target them by app version to achieve the same result in independent test. |
 | Can I add multiple Treatment groups to a single test? | No, you cannot add multiple Treatment groups to a single test. However, by running multiple tests on the same audience to capture each desired variant you can achieve the same result. |
 | Can I edit the enrollment criteria of a started experiment? | Before an experiment has been started, all aspects of enrollment criteria can be edited. However, once an experiment has been started, only new customers to enroll can be edited; since editing the audience that an experiment is exposed to would alter the nature of the test. |
-| Can I restart an experiment after it's been stopped? | After you choose to stop an experiment, new customers will no longer be enrolled in it, and it cannot be restarted. If you want to continue a test, create a new experiment and choose the same Offerings as the stopped experiment. _(NOTE: Results for stopped experiments will continue to refresh for 400 days after the experiment has ended)_ |
+| Can I restart an experiment after it's been stopped? | After you choose to stop an experiment, new customers will no longer be enrolled in it, and it cannot be restarted. If you want to continue a test, create a new experiment and choose the same Offerings as the stopped experiment. You can use the **duplicate** feature to quickly recreate the same experiment configuration. _(NOTE: Results for stopped experiments will continue to refresh for 400 days after the experiment has ended)_ |
+| Can I duplicate an experiment? | Yes, you can duplicate any existing experiment from the experiments list using the context menu. This creates a new experiment with the same configuration as the original, which you can then modify as needed before starting. This is useful for running similar tests or follow-up experiments. |
 | What happens to customers that were enrolled in an experiment after it's been stopped? | New customers will no longer be enrolled in an experiment after it's been stopped, and customers who were already enrolled in the experiment will begin receiving the Default Offering if they reach a paywall again. Since we continually refresh results for 400 days after an experiment has been ended, you may see renewals from these customers in your results, since they were enrolled as part of the test while it was running; but new subscriptions started by these customers after the experiment ended and one-time purchases made after the experiment ended will not be included in the results. |
 

--- a/docs/tools/experiments-v1/experiments-overview-v1.md
+++ b/docs/tools/experiments-v1/experiments-overview-v1.md
@@ -55,7 +55,7 @@ Programmatically displaying the `current` Offering in your app when you fetch Of
 :::
 
 1. Create the Offerings that you want to test (make sure your app displays the `current` Offering.) You can skip this step if you already have the Offerings you want to test.
-2. Create an Experiment and choose the Offerings to test. By default you can choose one Offering per variant, but by creating Placements your Experiment can instead have a unique Offering displayed for each paywall location in your app. [Learn more here](https://www.revenuecat.com/docs/tools/experiments-v1/configuring-experiments-v1#using-placements-in-experiments).
+2. Create an Experiment and choose the Offerings to test. You can create a new experiment from scratch or duplicate an existing experiment to save time when testing similar configurations. By default you can choose one Offering per variant, but by creating Placements your Experiment can instead have a unique Offering displayed for each paywall location in your app. [Learn more here](https://www.revenuecat.com/docs/tools/experiments-v1/configuring-experiments-v1#using-placements-in-experiments).
 3. Run your experiment and monitor the results. There is no time limit on experiments, so stop it when you feel confident choosing an outcome. (Learn more about interpreting your results [here](/tools/experiments-v1/experiments-results-v1))
 4. Once you’re satisfied with the results you can set the winning Offering(s), if any, as default manually.
 5. Then, you're ready to run a new experiment.
@@ -99,3 +99,5 @@ Sometimes you want to compare a different Offering to the one that is already th
 **Run follow-up tests after completing one test**
 
 After you run a test and find that one Offering won over the other, try running another test comparing the winning Offering against another similar Offering. This way, you can continually optimize for lifetime value (LTV). For example, if you were running a price test between a $5 product and a $7 product and the $7 Offering won, try running another test between a $8 product and the $7 winner to find the optimal price for the product that results in the highest LTV.
+
+You can use the **duplicate experiment** feature to quickly set up follow-up tests with similar configurations, making it easy to iterate and optimize your results over time.


### PR DESCRIPTION
## Summary
- Add comprehensive documentation for the new duplicate experiment feature
- Include step-by-step instructions for using the context menu to duplicate experiments
- Update experiment workflow overview to mention duplication option

## Changes Made
- **configuring-experiments-v1.md**: Added new section on duplicating experiments with detailed instructions and use cases
- **experiments-overview-v1.md**: Updated implementation steps and follow-up testing tips to mention duplicate feature
- **FAQ updates**: Added new FAQ entry about experiment duplication and enhanced existing entries

## Test plan
- [x] Verify documentation builds correctly
- [x] Ensure pre-commit hooks pass (formatting and typos)
- [x] Review content for clarity and completeness

🤖 Generated with [Claude Code](https://claude.ai/code)