### PR TITLE
Update creating-play-service-credentials.mdx to point alternative permission management approach

### DIFF
--- a/docs/service-credentials/creating-play-service-credentials.mdx
+++ b/docs/service-credentials/creating-play-service-credentials.mdx
@@ -86,7 +86,7 @@ While you're in the Google Cloud Console, get a head start on setting up Google 
 - Where: Google Play Console
 - Developer homepage ➡️ Users and permissions
 
-In the Google Play Console, go to the '**Users and Permissions**' section' and select invite user. You'll want to invite the service account you created in Step 2. Under 'App permissions' you need to add your app. Then under 'Account permissions', you need to grant certain permissions in order for RevenueCat to properly work.
+In the Google Play Console, go to the '**Users and Permissions**' section' and select invite user. You'll want to invite the service account you created in Step 2. Under 'App permissions' you need to add your app. Depending on what granularity of permission-control is desired, you need to grant certain permissions by either clicking on "Manage permissions" of the app you just added or, in order to grant access to all available apps, under 'Account permissions', in order for RevenueCat to properly work. Depending on your setup, you may want to adopt the principle of least privilege.
 
 #### Grant the following permissions:
 


### PR DESCRIPTION
Please know: I am not yet aware if the statement there would be indeed correct.

However, it feels a bit odd to grant a service account permissions over the entire Google Play account instead of just the one app it is supposed to manage. 

If it can be confirmed that it's also possible to grant permissions just on app-level, then I would propose to mention this alternative in the documentation.