### PR TITLE
Add virtual currency alongside subscriptions and entitlements in docs

### DIFF
--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -5,7 +5,7 @@ excerpt: Get up and running with mobile subscriptions
 hidden: false
 ---
 
-This guide will walk you through how to get up and running with subscriptions and RevenueCat's SDK with only a few lines of code.
+This guide will walk you through how to get up and running with subscriptions, virtual currency, and RevenueCat's SDK with only a few lines of code.
 
 ## 1. Set up your RevenueCat account
 
@@ -34,9 +34,9 @@ Read more about setting up StoreKit Configuration files in our [Sandbox Testing]
   title="RevenueCat Products, Offerings, and Entitlements Explained"
 />
 
-Once your in-app products have been configured in [App Store Connect](/getting-started/entitlements/ios-products), [Google Play Console](/getting-started/entitlements/android-products), [Amazon Appstore](/getting-started/entitlements/amazon-product-setup), [Stripe](/getting-started/entitlements/stripe-products), or [Paddle](/getting-started/entitlements/paddle-products) you'll need to copy that configuration into the RevenueCat dashboard. RevenueCat uses an Entitlements system to control access to premium features, and Offerings to manage the set of products you offer to customers.
+Once your in-app products have been configured in [App Store Connect](/getting-started/entitlements/ios-products), [Google Play Console](/getting-started/entitlements/android-products), [Amazon Appstore](/getting-started/entitlements/amazon-product-setup), [Stripe](/getting-started/entitlements/stripe-products), or [Paddle](/getting-started/entitlements/paddle-products) you'll need to copy that configuration into the RevenueCat dashboard. RevenueCat uses an Entitlements system to control access to premium features, Virtual Currency for consumable digital goods, and Offerings to manage the set of products you offer to customers.
 
-Entitlements are the level of access that a customer is "entitled" to after purchasing a specific product, and Offerings is a simple way for you to organize the in-app products you wish to "offer" on your paywall and configure them remotely. We **recommend** utilizing these features to simplify your code and enable you to change products without releasing an app update.
+Entitlements are the level of access that a customer is "entitled" to after purchasing a specific product, Virtual Currency provides consumable digital goods that can be earned and spent, and Offerings is a simple way for you to organize the in-app products you wish to "offer" on your paywall and configure them remotely. We **recommend** utilizing these features to simplify your code and enable you to change products without releasing an app update.
 
 See [Configuring Products](/getting-started/entitlements) to set up your products and then organize them into Offerings or Entitlements.
 

--- a/docs/migrating-to-revenuecat/sdk-or-not/sdk-less-integration.mdx
+++ b/docs/migrating-to-revenuecat/sdk-or-not/sdk-less-integration.mdx
@@ -29,8 +29,8 @@ If you are planning on using RevenueCat integrations with third party tools, ple
 
 [Read more about identifying customers →](/customers/user-ids)
 
-### Subscription and Entitlement Status
+### Subscription, Entitlement, and Virtual Currency Status
 
-Even if you don't use the SDK, you can use RevenueCat as your source of the truth for subscription and entitlement status. To do so, start by setting up [products and entitlements in RevenueCat](/getting-started/entitlements), and then use the `GET /subscribers/{app_user_id}` [REST API endpoint](/api-v1#tag/customers) to access information about a customer's subscriptions, purchases, and entitlements.
+Even if you don't use the SDK, you can use RevenueCat as your source of the truth for subscription, entitlement, and virtual currency status. To do so, start by setting up [products and entitlements in RevenueCat](/getting-started/entitlements), and then use the `GET /subscribers/{app_user_id}` [REST API endpoint](/api-v1#tag/customers) to access information about a customer's subscriptions, purchases, entitlements, and virtual currency balances.
 
-Alternatively, if you prefer to keep a copy of a customer's purchase and entitlement status in your own database, you can also listen to RevenueCat's [webhooks](/integrations/webhooks) to update your database whenever there is a new or updated purchase.
+Alternatively, if you prefer to keep a copy of a customer's purchase, entitlement, and virtual currency status in your own database, you can also listen to RevenueCat's [webhooks](/integrations/webhooks) to update your database whenever there is a new or updated purchase.

--- a/docs/offerings/offerings.md
+++ b/docs/offerings/offerings.md
@@ -52,7 +52,7 @@ For Google Play store products, if you select a non backwards-compatible product
 </details>
 
 :::info
-Any product can be added to an Offering, even if it's not part of any Entitlement. This can come in handy if your app's paywall contains a combination of subscription products that unlock Entitlements, and consumable products that do not.
+Any product can be added to an Offering, even if it's not part of any Entitlement. This can come in handy if your app's paywall contains a combination of subscription products that unlock Entitlements, products that grant Virtual Currency, and other consumable products.
 :::
 
 Continue this process until all of the packages are created for your Offering, and all Offerings are created.

--- a/docs/web/web-billing/overview.mdx
+++ b/docs/web/web-billing/overview.mdx
@@ -7,7 +7,7 @@ hidden: false
 
 # RevenueCat Web overview
 
-RevenueCat Web provides a set of tools that allow you to easily start selling subscriptions and one-time purchases on the web, and connect them with the same subscriptions and entitlements on mobile — either using RevenueCat's own billing engine (RC Web Billing) or by connecting 3rd party billing engines.
+RevenueCat Web provides a set of tools that allow you to easily start selling subscriptions and one-time purchases on the web, and connect them with the same subscriptions, entitlements, and virtual currencies on mobile — either using RevenueCat's own billing engine (RC Web Billing) or by connecting 3rd party billing engines.
 
 ## Features & use cases
 

--- a/docs/welcome/building-new.md
+++ b/docs/welcome/building-new.md
@@ -24,6 +24,7 @@ If you're launching a new app or adding subscriptions to your app for the first 
 Making purchases is just the beginning. Explore the docs to learn about how you can:
 
 - Gate features in your app and design more complex access models. [Learn about Entitlements →](/getting-started/entitlements)
+- Set up virtual currencies for consumable digital goods and in-game economies. [Learn about Virtual Currency →](/offerings/virtual-currency)
 - Dynamically change out the products on your paywall and run price experiments. [Set up your paywall Offerings →](/getting-started/displaying-products)
 - Set up winback campaigns to reduce churn. [See the free trial and discount options →](/subscription-guidance/subscription-offers)
 - Integrate subscription data from RevenueCat into all your other tools. [Check out integrations →](/integrations/integrations)

--- a/docs/welcome/overview.md
+++ b/docs/welcome/overview.md
@@ -33,8 +33,8 @@ Whether you have just one or one million subscribers, you can easily replace you
 ## Browse features
 
 <FeatureItem 
-  title="Entitlements & Subscription Status" 
-  subtitle="Ensure customers have correct access even if your entitlement structure is complex." 
+  title="Entitlements, Subscriptions, & Virtual Currency" 
+  subtitle="Manage subscriptions, entitlements, and virtual currencies to ensure customers have correct access." 
   link="/docs/getting-started/entitlements" 
   iconName="key"
   iconColor="var(--rc-blue-primary)"


### PR DESCRIPTION
## Summary
- Updated key documentation pages to consistently mention virtual currency as a core RevenueCat capability alongside subscriptions and entitlements
- Ensures users understand all three monetization approaches available in RevenueCat
- Maintains consistency across the documentation following the launch of the virtual currency feature

## Changes Made
- **Welcome overview**: Updated main feature item title and description to include virtual currency
- **Quickstart guide**: Added virtual currency to introduction and product configuration explanations  
- **Building new apps guide**: Added virtual currency bullet point to capabilities list
- **Web billing overview**: Included virtual currency in platform description
- **Offerings documentation**: Updated to mention virtual currency products in package descriptions
- **SDK-less integration guide**: Added virtual currency to status management section headers and descriptions

## Test plan
- [x] Verified all changes maintain proper markdown formatting
- [x] Confirmed links and references remain valid
- [x] Pre-commit hooks passed (formatting and spell checking)
- [x] Local dev server runs without errors

🤖 Generated with [Claude Code](https://claude.ai/code)