### PR TITLE
[Apple Shared Secret] Added SK1 and SK2 context

### DIFF
--- a/docs/service-credentials/itunesconnect-app-specific-shared-secret.mdx
+++ b/docs/service-credentials/itunesconnect-app-specific-shared-secret.mdx
@@ -8,7 +8,31 @@ hidden: false
 
 The App-Specific Shared Secret allows RevenueCat to connect with Apple on your behalf.
 
-## Setup
+## StoreKit Version Requirements
+
+The App-Specific Shared Secret is required for **StoreKit 1** implementations. For **StoreKit 2** apps, you'll need an [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) instead.
+
+### StoreKit 1
+
+- **Required**: App-Specific Shared Secret
+- **Use case**: Legacy apps, apps targeting iOS 15 or earlier
+- **Purpose**: Server-side receipt validation and subscription management
+
+### StoreKit 2
+
+- **Required**: [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) (Issuer ID + Key ID + Private Key)
+- **Use case**: Modern apps using iOS 16+ with RevenueCat SDK v5.0+
+- **Purpose**: Server-to-server communication with Apple's App Store Server API
+
+:::info
+New apps are recommended to use StoreKit 2. See our [migration guide](/sdk-guides/ios-native-4x-to-5x-migration) for details.
+:::
+
+## Setup (StoreKit 1 Only)
+
+:::warning
+This setup is only required for StoreKit 1 implementations. If you're using StoreKit 2, see [In-App Purchase Key Configuration](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration) instead.
+:::
 
 ### 1. Generating an App-Specific Shared Secret
 
@@ -28,3 +52,20 @@ The App-Specific Shared Secret allows RevenueCat to connect with Apple on your b
 Enter the secret in your iOS app settings in the RevenueCat dashboard:
 
 ![Shared secret input](/docs_images/credentials/apple/shared-secret-input.png)
+
+## Troubleshooting
+
+### Products/Offerings Not Loading
+
+If your products or offerings aren't appearing, ensure you've configured the appropriate credentials for your StoreKit version:
+
+- **StoreKit 1**: App-Specific Shared Secret (this page)
+- **StoreKit 2**: In-App Purchase Key
+
+### Migration Context
+
+If you're migrating from StoreKit 1 to StoreKit 2, you'll need to:
+
+1. Update to [RevenueCat SDK v5.0+](/sdk-guides/ios-native-4x-to-5x-migration)
+2. Configure an [In-App Purchase Key](/service-credentials/itunesconnect-app-specific-shared-secret/in-app-purchase-key-configuration)
+3. Remove the App-Specific Shared Secret configuration


### PR DESCRIPTION
## Motivation / Description

As per this [Slack](https://revenuecat.slack.com/archives/C036H1WM0T0/p1750929822299009) - we aren't explaining the need/context about the Apple Shared Secret. This adds it.

## Changes introduced

Added better context around the need/usage of it in SK1 and SK2 

To check: `[url]/docs/service-credentials/itunesconnect-app-specific-shared-secret`

## Linear ticket (if any)
n/a

## Additional comments
n/a