### PR TITLE
Document skip_purchase_success param

### DIFF
--- a/docs/web/web-billing/web-purchase-links.mdx
+++ b/docs/web/web-billing/web-purchase-links.mdx
@@ -179,3 +179,7 @@ Allows you to pre-select a package by referencing a RevenueCat `package_id` for 
 #### Custom metadata
 
 See [custom metadata](/web/web-billing/custom-metadata)
+
+#### Skip purchase success
+
+Add `skip_purchase_success=true` to bypass the final "Purchase Complete" step and immediately trigger your configured success behavior (success page or custom redirect).


### PR DESCRIPTION
## Summary
- document `skip_purchase_success` Web Purchase Link param to skip the final step

## Testing
- `yarn prettier --ignore-unknown --write docs/web/web-billing/web-purchase-links.mdx`

------
https://chatgpt.com/codex/tasks/task_b_68653a7d42ac8329bb40caaa56b82a01