### PR TITLE
[Playbooks] Add new category and links

### DIFF
--- a/docs/welcome/overview.md
+++ b/docs/welcome/overview.md
@@ -22,6 +22,10 @@ target="\_blank">Create an account →</Button>
 
 ## Start implementing
 
+:::info New!
+Check out our new [Playbooks](/playbooks/overview) section for guides and best practices for implementing different monetization models.
+:::
+
 Get started by creating a new project and connecting to a store.
 
 <Button href="/docs/projects/overview">Create a project →</Button>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -186,7 +186,7 @@ const config = {
               {
                 type: "docSidebar",
                 sidebarId: "playbookSidebar",
-                label: "Playbooks",
+                label: "Playbooks & Guides",
               },
             ],
           },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -39,22 +39,6 @@ const welcomeCategory = Category({
   items: [Page({ slug: "welcome/overview" })],
 });
 
-const playbooksCategory = Category({
-  iconName: "sparkle",
-  label: "Playbooks",
-  itemsPathPrefix: "playbooks/",
-  items: [
-    Page({ slug: "overview" }),
-    SubCategory({
-      label: "Guides",
-      slug: "guides",
-      itemsPathPrefix: "guides/",
-      items: [Page({ slug: "hard-paywall" }), Page({ slug: "freemium" })],
-      index: { title: "Guides", link: "playbooks/guides" },
-    }),
-  ],
-});
-
 const projectsCategory = Category({
   iconName: "hammer",
   label: "Projects & Apps",
@@ -1017,6 +1001,43 @@ const integrationsMoreCategory = Category({
   ],
 });
 
+const playbooksOverviewCategory = Category({
+  iconName: "sparkle",
+  label: "Playbooks",
+  itemsPathPrefix: "playbooks/",
+  items: [Page({ slug: "overview" })],
+});
+
+const playbooksMonetizationCategory = Category({
+  iconName: "currency-usd",
+  iconColor: "var(--ifm-color-success)",
+  label: "Monetization Models",
+  itemsPathPrefix: "playbooks/guides/",
+  items: [
+    Page({ slug: "hard-paywall" }),
+    Page({ slug: "freemium" }),
+    SubCategory({
+      label: "Other resources",
+      items: [
+        Link({
+          label: "Implementing virtual currencies and credits",
+          slug: "/offerings/virtual-currency",
+        }),
+        Link({
+          label: "Converting a paid app to subscriptions",
+          slug: "https://www.revenuecat.com/blog/engineering/converting-a-paid-ios-app-to-subscriptions/",
+        }),
+      ],
+      index: {
+        title: "Other resources",
+        description:
+          "Other resources for implementing different monetization models.",
+        link: "playbooks/guides/other-monetization-resources",
+      },
+    }),
+  ],
+});
+
 // Add the top level categories to the defaultSidebar object
 // The defaultSidebar is referenced in docusaurus.config.js
 const sidebars = {
@@ -1049,7 +1070,7 @@ const sidebars = {
     attributionCategory,
     integrationsMoreCategory,
   ],
-  playbookSidebar: [playbooksCategory],
+  playbookSidebar: [playbooksOverviewCategory, playbooksMonetizationCategory],
 };
 
 export default sidebars;

--- a/src/sidebars/sidebar-utils.ts
+++ b/src/sidebars/sidebar-utils.ts
@@ -141,7 +141,7 @@ export const Page = ({ slug }: PageConfig): DocItem => ({
 
 export const Link = ({ label, slug }: LinkConfig): LinkItem => ({
   type: "link",
-  label: `${label} →`,
+  label: `${label}${slug.includes("https://") ? " " : " →"}`,
   href: slug,
 });
 


### PR DESCRIPTION
## Motivation / Description

To start expanding playbooks, need to do a bit of maintenance to prepare for new categories and guides

## Changes introduced

- adds new monetization category with 'other resources' to link to non-playbook guides
- adds message to point to playbooks in the welcome page

## Linear ticket (if any)

## Additional comments
