### PR TITLE
fix: Rename `Payment Provider` tab to `Billing`

### DIFF
--- a/docs/web/web-billing/lifecycle-emails.mdx
+++ b/docs/web/web-billing/lifecycle-emails.mdx
@@ -29,7 +29,7 @@ Only the `Page background` and `Primary button` colors are used to brand emails.
 
 ## \[optional\] Lifecycle emails for auto-renewing subscriptions
 
-Two lifecycle emails can be enabled to comply with the latest (as of July 1st, 2025) California requirements for auto-renewing subscriptions. These emails can be enabled in: the **Payment provider** tab of your Web Billing configuration:
+Two lifecycle emails can be enabled to comply with the latest (as of July 1st, 2025) California requirements for auto-renewing subscriptions. These emails can be enabled in: the **Billing** tab of your Web Billing configuration:
 
 1. Upcoming renewal notifications for yearly subscriptions
 1. Upcoming free trial expiry notifications for trials longer than 1 month

--- a/docs/web/web-billing/tax.mdx
+++ b/docs/web/web-billing/tax.mdx
@@ -70,9 +70,9 @@ If you have not already configured Stripe Tax, you should follow the instruction
 Any tax rates added in your Stripe Tax dashboard in live mode may be applied to web billing transactions after this step. Make sure you haven't added registrations to live mode that are only for testing purposes.
 :::
 
-1. Navigate to the Web Billing payment provider in your RevenueCat account.
-1. In the **payment provider** tab, enable "automatically collect taxes using Stripe Tax" and save the changes.
-1. Still in the payment provider tab, Set the product tax code for your product. The default tax code is **General - Electronically Supplied Services** (`txcd_10000000`) which should be applicable for a lot of app-based businesses. For more guidance on product tax codes, see [Stripe's documentation](https://docs.stripe.com/tax/tax-codes).
+1. Navigate to the Web Billing configuration in your RevenueCat account.
+1. In the **Billing** tab, enable "Automatically detect and charge tax rates from Stripe Tax" and save the changes.
+1. Still in the **Billing** tab, Set the product tax code for your product. The default tax code is **General - Electronically Supplied Services** (`txcd_10000000`) which should be applicable for a lot of app-based businesses. For more guidance on product tax codes, see [Stripe's documentation](https://docs.stripe.com/tax/tax-codes).
 
 #### 3: Test tax collection in test mode
 


### PR DESCRIPTION
## Motivation / Description

The `Payment provider` tab from the web configuration has been renamed to `Billing`. This PR updates the docs accordingly

## Changes introduced

## Linear ticket (if any)

## Additional comments
