### PR TITLE
Changed $attConsentStatus  'accepted' to 'authorized'

### DIFF
--- a/docs/customers/customer-attributes.mdx
+++ b/docs/customers/customer-attributes.mdx
@@ -150,7 +150,7 @@ You may see the following as a response from this attribute:
 
 - `restricted` - Can be returned if the user is using a mobile device management profile that disallows some aspects of tracking regardless of consent. This might be returned even if you never ask for permissions.
 - `denied` - Can be returned if the user’s phone has set “Ask Apps Not To Track” in OS Settings or denied access for the specific app.
-- `accepted` - Returned if you ask for permission and the permission gets accepted by the user.
+- `authorized` - Returned if you ask for permission and the permission gets accepted by the user.
 - `unknown` - The user hasn’t set “Ask Apps Not to Track” in OS Settings, and you have never asked the user for consent to track activity.
   :::
 


### PR DESCRIPTION
As far as I can tell, the reference of `accepted` being a possible value of `$attConsentStatus` is incorrect.

https://github.com/RevenueCat/purchases-ios/blob/main/Sources/Networking/CustomerAPI.swift#L102

https://developer.apple.com/documentation/apptrackingtransparency/attrackingmanager/authorizationstatus/authorized

Please review this change closely and ensure you agree with my interpretation.