### PR TITLE
Fix bug in some Segment event JSON examples

### DIFF
--- a/code_blocks/integrations/third-party-integrations/segment_5.json
+++ b/code_blocks/integrations/third-party-integrations/segment_5.json
@@ -3,7 +3,8 @@
         "user_id": "$RCAnonymousID:87c6049c58069238dce29853916d624c",
         "event": "rc_trial_started_event",
         "properties": {
-            "price": 0.0,
+            "revenue": 0.0,
+            "currency": "USD",
             "store": "APP_STORE",
             "expires_at": 1556693063,
             "entitlement": "premium",

--- a/code_blocks/integrations/third-party-integrations/segment_6.json
+++ b/code_blocks/integrations/third-party-integrations/segment_6.json
@@ -3,7 +3,8 @@
         "user_id": "$RCAnonymousID:87c6049c58069238dce29853916d624c",
         "event": "rc_trial_converted_event",
         "properties": {
-            "price": 7.99,
+            "revenue": 7.99,
+            "currency": "USD",
             "store": "APP_STORE",
             "expires_at": 1558701211,
             "entitlement": "premium",

--- a/code_blocks/integrations/third-party-integrations/segment_8.json
+++ b/code_blocks/integrations/third-party-integrations/segment_8.json
@@ -3,7 +3,8 @@
         "user_id": "$RCAnonymousID:87c6049c58069238dce29853916d624c",
         "event": "rc_renewal_event",
         "properties": {
-            "price": 7.99,
+            "revenue": 7.99,
+            "currency": "USD",
             "store": "APP_STORE",
             "expires_at": 1558699811,
             "entitlement": "premium",

--- a/code_blocks/integrations/third-party-integrations/segment_9.json
+++ b/code_blocks/integrations/third-party-integrations/segment_9.json
@@ -3,7 +3,8 @@
         "user_id": "$RCAnonymousID:87c6049c58069238dce29853916d624c",
         "event": "rc_cancellation_event",
         "properties": {
-            "price": 0.0,
+            "revenue": 0.0,
+            "currency": "USD",
             "store": "APP_STORE",
             "expires_at": 1558116196,
             "entitlement": "premium",


### PR DESCRIPTION
## Motivation / Description
The [segment_event_dispatcher](https://github.com/RevenueCat/khepri/blob/main/khepri/events/dispatchers/segment_event_dispatcher.py#L204) does not use a `price` field. Instead, it uses `revenue` and `currency`.

`currency` is hard-coded to USD.

## Changes introduced

Resolves the discrepancy in affected events by renaming `price` to `revenue` and adding `"currency": "USD"` where it was missing.
