### PR TITLE
Mention custom actions on customer center docs

### DIFF
--- a/docs/tools/customer-center/customer-center-configuration.mdx
+++ b/docs/tools/customer-center/customer-center-configuration.mdx
@@ -116,6 +116,8 @@ Let's break down the configuration for each management option:
 
 5. **Custom URL**: Allows you to specify a custom URL that customers will be redirected to when they select this management option. This can also be used to link to other sections of your app using deeplinks.
 
+6. **Custom Action**: Allows to attach a custom identifier to a button, and execute your own code whenever the button is tapped.
+
 Key points about management options:
 
 - Management options can include a promotional offer to present discounts to customers.


### PR DESCRIPTION
## Motivation / Description
We've recently launched custom actions, and there's no mention in the docs.

## Changes introduced
- Add new path to documentation.
