### PR TITLE
Add BC8 migration guide

### DIFF
--- a/docs/sdk-guides/android-native-8x-to-9x-migration.mdx
+++ b/docs/sdk-guides/android-native-8x-to-9x-migration.mdx
@@ -1,0 +1,34 @@
+---
+title: Android Native - 8.x to 9.x Migration
+slug: android-native-8x-to-9x-migration
+hidden: false
+---
+
+## RevenueCat SDK
+
+:::warning
+If you don't have any login system in your app, please make sure your one-time purchase products have been correctly configured in the RevenueCat dashboard as either consumable or non-consumable. If they're incorrectly configured as consumables, RevenueCat will consume these purchases. This means that customers won't be able to restore them from version 9.0.0 onward.
+
+Non-consumables are products that are meant to be bought only once, for example, lifetime subscriptions.
+:::
+
+This release updates the SDK to use Google Play Billing Library 8. This version of the Billing Library removed APIs to query for expired subscriptions and consumed one-time products, aside from other improvements. You can check the full list of changes here: https://developer.android.com/google/play/billing/release-notes#8-0-0
+
+Additionally, we've also updated Kotlin to 2.0.21 and our new minimum version is Kotlin 1.8.0+. If you were using an older version of Kotlin, you will need to update it.
+
+Regarding API changes, we've also removed data classes from our public APIs. This means that for classes that were previously data classes, the `copy` function and `componentN` functions (destructuring declarations) have been removed. `equals` and `hashCode` functions still work as before.
+
+### Play Billing Library 8: No expired subscriptions or consumed one-time products
+
+Play Billing Library 8 removed the ability to query for expired subscriptions and consumed one-time products. This means that the RevenueCat SDK will no longer be able to send purchase information from these purchases. There are 2 cases where this can have an impact:
+
+- If you have consumed one time purchases in Google Play that need to be restored (for example, in order to grant a lifetime entitlement). In these cases, the SDK will not be able to find these purchases and will not be able to restore them and grant the entitlements. This can especially be a problem if you're using anonymous ids and don't have your own account system. Please make sure your products are correctly configured as non-consumables in the RevenueCat dashboard to avoid consuming them in the first place if you intend to make them behave as lifetime purchases.
+- (Only relevant if you recently integrated RevenueCat before upgrading to v9, and do not (yet) have all your transactions imported). The SDK will not be able to send purchase information from these expired subscriptions and consumed one time purchases to our backend, so we might miss this data in our customer profile/targeting. We can still ingest historical data from these purchases through a backend historical import. See [docs](https://www.revenuecat.com/docs/migrating-to-revenuecat/migrating-existing-subscriptions). This case doesn't affect developers that have all transactions in RevenueCat, which is true for the vast majority.
+
+### Bumped minimum Kotlin version
+
+RevenueCat SDK v9 bumps Kotlin to 2.0.21, with a minimum Kotlin version of 1.8.0.
+
+### Using the SDK with your own IAP code (previously Observer Mode)
+
+Using the SDK with your own IAP code is still supported in v9. Other than updating the SDK version, there are no changes required. Just make sure the version of the Play Billing Library is also version 8.0.0+.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -636,6 +636,7 @@ const sdkMigrationCategory = Category({
         Page({ slug: "android-native-5x-to-6x-migration" }),
         Page({ slug: "android-native-6x-to-7x-migration" }),
         Page({ slug: "android-native-7x-to-8x-migration" }),
+        Page({ slug: "android-native-8x-to-9x-migration" }),
       ],
       index: {
         title: "Android Migration Guides",


### PR DESCRIPTION
## Motivation / Description
Taken from the [SDK's migration guide](https://github.com/RevenueCat/purchases-android/releases/tag/9.0.0)

## Changes introduced

## Linear ticket (if any)

## Additional comments
