### PR TITLE
Add a top-level targeting category

### DIFF
--- a/docs/tools/targeting.md
+++ b/docs/tools/targeting.md
@@ -1,6 +1,8 @@
 ---
-title: Offering Targeting
+title: Targeting
+description: Create rules to serve distinct audiences their own Offerings.
 slug: targeting
+sidebar_label: Overview
 hidden: false
 ---
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -294,15 +294,6 @@ const offeringsCategory = Category({
       ],
     }),
     SubCategory({
-      label: "Targeting",
-      slug: "tools/targeting",
-      itemsPathPrefix: "tools/targeting/",
-      items: [
-        Page({ slug: "placements" }),
-        Page({ slug: "custom-attributes" }),
-      ],
-    }),
-    SubCategory({
       label: "Product Configuration",
       slug: "offerings/products-overview",
       itemsPathPrefix: "",
@@ -357,6 +348,17 @@ const offeringsCategory = Category({
       ],
     }),
     Page({ slug: "offerings/troubleshooting" }),
+  ],
+});
+
+const targetingCategory = Category({
+  iconName: "target",
+  label: "Targeting",
+  itemsPathPrefix: "",
+  items: [
+    Page({ slug: "tools/targeting" }),
+    Page({ slug: "tools/targeting/placements" }),
+    Page({ slug: "tools/targeting/custom-attributes" }),
   ],
 });
 
@@ -1149,6 +1151,7 @@ const sidebars = {
     paywallsCategory,
     testCategory,
     launchCategory,
+    targetingCategory,
     experimentsCategory,
     chartsDummyCategory,
     integrationsDummyCategory,


### PR DESCRIPTION
## Motivation / Description

Renaming the old 'offerings' category to product catalog makes targeting a bit out of place. should be it's own category

@dpannasch 

## Changes introduced

- Adds targeting to the top level categories

## Linear ticket (if any)

## Additional comments
