### PR TITLE
correct a file and add a comment to save a developer time in the future

### DIFF
--- a/code_blocks/tools/paywalls_2.swift
+++ b/code_blocks/tools/paywalls_2.swift
@@ -11,7 +11,7 @@ struct App: View {
                 return customerInfo.entitlements.active.keys.contains("pro")
             } purchaseCompleted: { customerInfo in
                 print("Purchase completed: \(customerInfo.entitlements)")
-            } restoreCompleted: {
+            } restoreCompleted: { customerInfo in
                 // Paywall will be dismissed automatically if "pro" is now active.
                 print("Purchases restored: \(customerInfo.entitlements)")
             }

--- a/code_blocks/tools/paywalls_3_new.swift
+++ b/code_blocks/tools/paywalls_3_new.swift
@@ -10,7 +10,8 @@ struct App: View {
     var body: some View {
         ContentView()
             .sheet(isPresented: self.$displayPaywall) {
-                PaywallView()
+                // We handle scroll views for you, no need to wrap this in a ScrollView
+                PaywallView() 
             }
     }
-} 
+}   


### PR DESCRIPTION
## Motivation / Description

We had a user send in a support ticket because they had a paywall get compressed, their fix was to give it a 2000px frame. When reviewing the issue it sounded like a nested scrollview issue. I was able to clone the paywall and validate that nesting scrollviews is indeed the issue. When going through our docs to set up a paywall, I noticed one spot that was wrong, and another that could have used a comment to prevent the situation.

## Changes introduced

Modifies 2 swift code blocks, one for correctness, the other to add a comment that deters developers from wrapping the paywall in a scrollview
