### PR TITLE
Re-allow developer collaborators to create app configs

### DIFF
--- a/docs/projects/collaborators.md
+++ b/docs/projects/collaborators.md
@@ -57,8 +57,6 @@ All roles and permission levels are now available on every plan, giving teams th
 
 ❌ This role cannot generate Secret API keys. See [secret key permission levels](/projects/authentication) for details.
 
-❌ This role cannot add App or Web configurations.
-
 ---
 
 #### **Support**


### PR DESCRIPTION
## Motivation / Description
The ability to create app/web configs was removed by mistake on the dashboard. We're reverting to the previous behavior. 

## TODOs:
- [x] Merge dashboard PR first


## Changes introduced

## Linear ticket (if any)

## Additional comments
