### PR TITLE
Update Expo installation instructions

### DIFF
--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -37,6 +37,12 @@ This command will create a default project with example code, and install the Ex
 npx create-expo-app@latest
 ```
 
+Make sure to install the [expo-dev-client](https://docs.expo.dev/versions/latest/sdk/dev-client/):
+
+```sh
+npx expo install expo-dev-client
+```
+
 Ensure you're in the project directory for the following steps:
 
 ```sh

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -27,19 +27,19 @@ This guide is specific to Expo, but you may also find our [React Native guide](/
 
 ## Create an Expo development build
 
-### Install Expo CLI and development dependencies
+### Set up the Expo project
 
-### Get started with an Expo project
+You can use an existing Expo project, or [create a new one](https://docs.expo.dev/get-started/create-a-project/).
 
-Either create a new Expo project with the following command:
+This command will create a default project with example code, and install the Expo CLI as a dependency:
 
-```
+```sh
 npx create-expo-app@latest
 ```
 
-or use an existing Expo project. Ensure you're in the project directory for the following steps:
+Ensure you're in the project directory for the following steps:
 
-```
+```sh
 cd <expo-project-directory>
 ```
 
@@ -49,7 +49,7 @@ Install RevenueCat's `react-native-purchases` for core functionality and `react-
 
 Either run:
 
-```
+```sh
 npx expo install react-native-purchases react-native-purchases-ui
 ```
 
@@ -145,19 +145,19 @@ You can also follow these instructions on Expo's docs: https://docs.expo.dev/tut
 
 Get started by installing the EAS-CLI:
 
-```
+```sh
 npm install -g eas-cli
 ```
 
 Then login to EAS:
 
-```
+```sh
 eas login
 ```
 
 After logging in, initialize the EAS configuration:
 
-```
+```sh
 eas init
 ```
 
@@ -212,7 +212,7 @@ Enter your app's bundle ID, matching your RevenueCat config and App Store Connec
 
 After your app is running, you'll need to start the Expo server:
 
-```
+```sh
 npx expo start
 ```
 
@@ -224,7 +224,7 @@ To test on an Android device, you'll need to build the app for a physical device
 
 Please ensure that `developmentClient` in your `eas.json` file is set to true under the `build.development` profile. Then, build the app:
 
-```
+```sh
 eas build --platform android --profile development
 ```
 
@@ -236,7 +236,7 @@ To run the app on an [Android emulator](https://docs.expo.dev/tutorial/eas/andro
 
 After the app is running, you'll need to start the Expo server:
 
-```
+```sh
 npx expo start
 ```
 

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -29,18 +29,6 @@ This guide is specific to Expo, but you may also find our [React Native guide](/
 
 ### Install Expo CLI and development dependencies
 
-Start by installing [Expo CLI](https://docs.expo.dev/more/expo-cli/):
-
-```
-npm install expo -g
-```
-
-and then install [Expo DevClient](https://docs.expo.dev/versions/latest/sdk/dev-client/):
-
-```
-npx expo install expo-dev-client
-```
-
 ### Get started with an Expo project
 
 Either create a new Expo project with the following command:
@@ -49,7 +37,7 @@ Either create a new Expo project with the following command:
 npx create-expo-app@latest
 ```
 
-or use an existing Expo project. Ensure you're in the project directory for the next steps:
+or use an existing Expo project. Ensure you're in the project directory for the following steps:
 
 ```
 cd <expo-project-directory>

--- a/docs/getting-started/installation/expo.mdx
+++ b/docs/getting-started/installation/expo.mdx
@@ -37,16 +37,16 @@ This command will create a default project with example code, and install the Ex
 npx create-expo-app@latest
 ```
 
-Make sure to install the [expo-dev-client](https://docs.expo.dev/versions/latest/sdk/dev-client/):
-
-```sh
-npx expo install expo-dev-client
-```
-
-Ensure you're in the project directory for the following steps:
+Change to the project directory:
 
 ```sh
 cd <expo-project-directory>
+```
+
+Install the [expo-dev-client](https://docs.expo.dev/versions/latest/sdk/dev-client/):
+
+```sh
+npx expo install expo-dev-client
 ```
 
 ### Install RevenueCat's SDKs


### PR DESCRIPTION
## Motivation / Description

`npm install -g expo` installs `expo` globally and is invalid. It's hard to predict what consequences installing `expo` globally will have.

These instructions are also out-of-order, which may be accidental. Installing the `expo-dev-client` comes too early since it's in a section before this proposes to create an app. The instructions for a Development Build are already at the top.

## Changes introduced

- Remove installation section

## Linear ticket (if any)

## Additional comments

It's a little unclear to me what the intention or order was meant to be. It's likely that this may need some refinement but the main motivation was to remove the global `expo` installation instruction.
