### PR TITLE
Add android backup docs

### DIFF
--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -57,37 +57,47 @@ import xmlContent from "@site/code_blocks/getting-started/installation/android_w
 />
 :::
 
-### Backup RevenueCat data / Proactive restores (Experimental/Optional)
-
-When a user uninstalls and reinstalls or changes devices, unless you are using your own account system, you must provide a restore purchases button somewhere in your app so users can recover any previously performed purchases. RevenueCat provides an easy to use `restorePurchases` method in our SDKs to do this. However, some customers might run into difficulties with this process. In these cases, Google provides some mechanisms to perform backups of your app's contents so they are available when your users move to new devices, or uninstall and reinstall within the same device. This might require some setup to make sure the backup include RevenueCat information correctly.
-
-:::note
-Making sure your backup setup is correctly configured is highly recommended for developers that don't use an account system that allow users to sign up/sign in to recover their data.
-:::
+### Enhanced Restores with Billing Client 8 (Optional)
 
 :::warning
-We highly recommend developers that do not have an account system and that have/had non-consumable products configured as consumables in the RevenueCat dashboard to configure this correctly.
-This will help minimize the effects of Google removing the capability of querying for consumed one time products in the Google Play Billing Library 8, which could cause issues of losing these purchases forever.
+We highly recommend developers that do NOT have an account system and that use or have used One time products to configure this correctly.
 :::
 
-There are 2 recommended approaches you can take to perform backups, [Auto Backup](https://developer.android.com/identity/data/autobackup) and [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
-In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you back up. 
+Starting on Billing Client 8, Google removed the ability to query consumed one time purchases through Google's Billing Client library. This means that our SDK won't be able to restore these purchases.
+
+This can be problematic if both:
+- Your app DOESN'T offer an account system (so users can't log in to recover their purchases) and you rely on RevenueCat's anonymous users AND
+- Your app has or had at any point in time, one time products configured as consumables in the RevenueCat dashboard that you would like to be able to restore. In this case, RevenueCat would have consumed those purchases, making them not available to find them through the Billing Client.
+
+In this scenario, these users will have anonymous user ids that won't be easily recoverable and won't be able to recover their purchases through the Billing Client, potentially increasing support requests.
+
+One way to reduce the impact of this issue is by making sure RevenueCat's data is safely backed up in the user's Google account, so it is automatically restored when the user reinstalls the app and/or changes devices. RevenueCat stores data in its own SharedPreferences file. The exact name of that file is available as the constant `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`, which you can reference when setting up backups. We recommend you also include your app's default SharedPreferences file. 
+
+There are 2 recommended approaches Google offers to perform backups:
+- [Auto Backup](https://developer.android.com/identity/data/autobackup)
+- [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
 
 #### Auto Backup
-Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to back up following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
+Auto Backup is enabled by default in your app. This backs up most of your app content, including the RevenueCat SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles).
 
-We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the SharedPreferences files are included.
+We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the RevenueCat SharedPreferences file is included.
 
 #### Key-Value backups
-Please note that doing this will disable Auto backup and will just back up RevenueCat files!
+Please note that enabling this will disable Auto backup and will just back up RevenueCat files!
 
-If you prefer to disable auto-backup and just copy the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
+If you prefer to disable auto-backup and just back up the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
 
 ```xml
 android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
 ```
 
-That's it!
+#### What should you do?
+For the majority of apps, Auto Backup is enabled by default and should handle backups for you without doing anything. However, there are some situations where it won't:
+- If your app has the potential of having more than 25MB of data over the files that Auto Backup automatically backs up (See [docs](https://developer.android.com/identity/data/autobackup#Files))
+- If you have modified the files you would like to backup using Auto Backup and have not included RevenueCat's SharedPreferences file.
+- If you have disabled backups
+
+If you are in one of those positions, we recommend you make sure your backup configuration includes the RevenueCat SharedPreferences file without going over the 25MB limit, or, in case you have backups disabled, you may enable auto backup only for this file or just add the `RevenueCatBackupAgent` to your AndroidManifest.xml application, as mentioned above.
 
 #### How to test backups
 Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -71,7 +71,7 @@ This will help minimize the effects of Google removing the capability of queryin
 :::
 
 There are 2 recommended approaches you can take to perform backups, [Auto Backup](https://developer.android.com/identity/data/autobackup) and [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
-In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you backup. 
+In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you back up. 
 
 #### Auto Backup
 Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -79,7 +79,7 @@ Auto Backup is enabled by default in your apps. This backs up most of your app c
 We recommend adjusting the files you want to backup to make sure you don't go over the limit and making sure the SharedPreferences files are included.
 
 #### Key-Value backups
-Please note that doing this will disable Auto backup and will just backup RevenueCat files!
+Please note that doing this will disable Auto backup and will just back up RevenueCat files!
 
 If you prefer to disable auto-backup and just copy the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -92,7 +92,7 @@ That's it!
 #### How to test backups
 Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).
 
-One thing to note, however, is that these backups are not guaranteed to work accross all devices and might require factory resets in the target device to use the backup.
+One thing to note, however, is that these backups are not guaranteed to work across all devices and might require factory resets in the target device to use the backup.
 
 ### Set the correct launchMode
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -74,7 +74,7 @@ There are 2 recommended approaches you can take to perform backups, [Auto Backup
 In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you backup. 
 
 #### Auto Backup
-Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentatio](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
+Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
 
 We recommend adjusting the files you want to backup to make sure you don't go over the limit and making sure the SharedPreferences files are included.
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -83,7 +83,7 @@ Please note that doing this will disable Auto backup and will just backup Revenu
 
 If you prefer to disable auto-backup and just copy the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
 
-```
+```xml
 android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
 ```
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -99,6 +99,8 @@ For the majority of apps, Auto Backup is enabled by default and should handle ba
 
 If you are in one of those positions, we recommend you make sure your backup configuration includes the RevenueCat SharedPreferences file without going over the 25MB limit, or, in case you have backups disabled, you may enable auto backup only for this file or just add the `RevenueCatBackupAgent` to your AndroidManifest.xml application, as mentioned above.
 
+Both options are powered by similar Google backup mechanisms and either should work pretty similarly, so we recommend using Auto Backup unless there is a reason you prefer to use a Backup Agent.
+
 #### How to test backups
 Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -74,7 +74,7 @@ There are 2 recommended approaches you can take to perform backups, [Auto Backup
 In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you back up. 
 
 #### Auto Backup
-Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
+Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to back up following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
 
 We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the SharedPreferences files are included.
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -76,7 +76,7 @@ In either case, we recommend you make sure to include your app's default SharedP
 #### Auto Backup
 Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
 
-We recommend adjusting the files you want to backup to make sure you don't go over the limit and making sure the SharedPreferences files are included.
+We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the SharedPreferences files are included.
 
 #### Key-Value backups
 Please note that doing this will disable Auto backup and will just back up RevenueCat files!

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -67,7 +67,7 @@ Making sure your backup setup is correctly configured is highly recommended for 
 
 :::warning
 We highly recommend developers that do not have an account system and that have/had non-consumable products configured as consumables in the RevenueCat dashboard to configure this correctly.
-This will help minimize the effects of Google removing the capability of querying for consumed one time products through the Billing library, which could cause issues of losing these purchases forever.
+This will help minimize the effects of Google removing the capability of querying for consumed one time products in the Google Play Billing Library 8, which could cause issues of losing these purchases forever.
 :::
 
 There are 2 recommended approaches you can take to perform backups, [Auto Backup](https://developer.android.com/identity/data/autobackup) and [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -57,55 +57,6 @@ import xmlContent from "@site/code_blocks/getting-started/installation/android_w
 />
 :::
 
-### Enhanced Restores with Billing Client 8 (Optional)
-
-:::warning
-We highly recommend developers that do NOT have an account system and that use or have used One time products to configure this correctly.
-:::
-
-Starting on Billing Client 8, Google removed the ability to query consumed one time purchases through Google's Billing Client library. This means that our SDK won't be able to restore these purchases.
-
-This can be problematic if both:
-- Your app DOESN'T offer an account system (so users can't log in to recover their purchases) and you rely on RevenueCat's anonymous users AND
-- Your app has or had at any point in time, one time products configured as consumables in the RevenueCat dashboard that you would like to be able to restore. In this case, RevenueCat would have consumed those purchases, making them not available to find them through the Billing Client.
-
-In this scenario, these users will have anonymous user ids that won't be easily recoverable and won't be able to recover their purchases through the Billing Client, potentially increasing support requests.
-
-One way to reduce the impact of this issue is by making sure RevenueCat's data is safely backed up in the user's Google account, so it is automatically restored when the user reinstalls the app and/or changes devices. RevenueCat stores data in its own SharedPreferences file. The exact name of that file is available as the constant `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`, which you can reference when setting up backups. We recommend you also include your app's default SharedPreferences file. 
-
-There are 2 recommended approaches Google offers to perform backups:
-- [Auto Backup](https://developer.android.com/identity/data/autobackup)
-- [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
-
-#### Auto Backup
-Auto Backup is enabled by default in your app. This backs up most of your app content, including the RevenueCat SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles).
-
-We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the RevenueCat SharedPreferences file is included.
-
-#### Key-Value backups
-Please note that enabling this will disable Auto backup and will just back up RevenueCat files!
-
-If you prefer to disable auto-backup and just back up the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
-
-```xml
-android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
-```
-
-#### What should you do?
-For the majority of apps, Auto Backup is enabled by default and should handle backups for you without doing anything. However, there are some situations where it won't:
-- If your app has the potential of having more than 25MB of data over the files that Auto Backup automatically backs up (See [docs](https://developer.android.com/identity/data/autobackup#Files))
-- If you have modified the files you would like to backup using Auto Backup and have not included RevenueCat's SharedPreferences file.
-- If you have disabled backups
-
-If you are in one of those positions, we recommend you make sure your backup configuration includes the RevenueCat SharedPreferences file without going over the 25MB limit, or, in case you have backups disabled, you may enable auto backup only for this file or just add the `RevenueCatBackupAgent` to your AndroidManifest.xml application, as mentioned above.
-
-Both options are powered by similar Google backup mechanisms and either should work pretty similarly, so we recommend using Auto Backup unless there is a reason you prefer to use a Backup Agent.
-
-#### How to test backups
-Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).
-
-One thing to note, however, is that these backups are not guaranteed to work across all devices and might require factory resets in the target device to use the backup.
-
 ### Set the correct launchMode
 
 Depending on your user's payment method, they may be asked by Google Play to verify their purchase in their (banking) app. This means they will have to background your app and go to another app to verify the purchase. If your Activity's `launchMode` is set to anything other than `standard` or `singleTop`, backgrounding your app can cause the purchase to get cancelled. To avoid this, set the `launchMode` of your Activity to `standard` or `singleTop` in your `AndroidManifest.xml` file, like so:

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -65,6 +65,11 @@ When a user uninstalls and reinstalls or changes devices, unless you are using y
 Making sure your backup setup is correctly configured is highly recommended for developers that don't use an account system that allow users to sign up/sign in to recover their data.
 :::
 
+:::warning
+We highly recommend developers that have/had non-consumable products configured as consumables in the RevenueCat dashboard to configure this correctly.
+This will help minimize the effects of Google removing the capability of querying for consumed one time products through the Billing library, which could cause issues of losing these purchases forever.
+:::
+
 There are 2 recommended approaches you can take to perform backups, [Auto Backup](https://developer.android.com/identity/data/autobackup) and [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
 In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you backup. 
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -66,7 +66,7 @@ Making sure your backup setup is correctly configured is highly recommended for 
 :::
 
 :::warning
-We highly recommend developers that have/had non-consumable products configured as consumables in the RevenueCat dashboard to configure this correctly.
+We highly recommend developers that do not have an account system and that have/had non-consumable products configured as consumables in the RevenueCat dashboard to configure this correctly.
 This will help minimize the effects of Google removing the capability of querying for consumed one time products through the Billing library, which could cause issues of losing these purchases forever.
 :::
 

--- a/docs/getting-started/installation/android.mdx
+++ b/docs/getting-started/installation/android.mdx
@@ -57,6 +57,38 @@ import xmlContent from "@site/code_blocks/getting-started/installation/android_w
 />
 :::
 
+### Backup RevenueCat data / Proactive restores (Experimental/Optional)
+
+When a user uninstalls and reinstalls or changes devices, unless you are using your own account system, you must provide a restore purchases button somewhere in your app so users can recover any previously performed purchases. RevenueCat provides an easy to use `restorePurchases` method in our SDKs to do this. However, some customers might run into difficulties with this process. In these cases, Google provides some mechanisms to perform backups of your app's contents so they are available when your users move to new devices, or uninstall and reinstall within the same device. This might require some setup to make sure the backup include RevenueCat information correctly.
+
+:::note
+Making sure your backup setup is correctly configured is highly recommended for developers that don't use an account system that allow users to sign up/sign in to recover their data.
+:::
+
+There are 2 recommended approaches you can take to perform backups, [Auto Backup](https://developer.android.com/identity/data/autobackup) and [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
+In either case, we recommend you make sure to include your app's default SharedPreferences file and RevenueCat's SharedPreferences file (You can find the name of this SharedPreferences file by doing `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`) in the files you backup. 
+
+#### Auto Backup
+Auto Backup is enabled by default in your apps. This backs up most of your app content, including the RevenueCat relevant SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentatio](https://developer.android.com/identity/data/autobackup#IncludingFiles). 
+
+We recommend adjusting the files you want to backup to make sure you don't go over the limit and making sure the SharedPreferences files are included.
+
+#### Key-Value backups
+Please note that doing this will disable Auto backup and will just backup RevenueCat files!
+
+If you prefer to disable auto-backup and just copy the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
+
+```
+android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
+```
+
+That's it!
+
+#### How to test backups
+Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).
+
+One thing to note, however, is that these backups are not guaranteed to work accross all devices and might require factory resets in the target device to use the backup.
+
 ### Set the correct launchMode
 
 Depending on your user's payment method, they may be asked by Google Play to verify their purchase in their (banking) app. This means they will have to background your app and go to another app to verify the purchase. If your Activity's `launchMode` is set to anything other than `standard` or `singleTop`, backgrounding your app can cause the purchase to get cancelled. To avoid this, set the `launchMode` of your Activity to `standard` or `singleTop` in your `AndroidManifest.xml` file, like so:

--- a/docs/getting-started/restoring-purchases.mdx
+++ b/docs/getting-started/restoring-purchases.mdx
@@ -77,7 +77,7 @@ There are 2 recommended approaches Google offers to perform backups:
 - [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
 
 #### Auto Backup
-Auto Backup is enabled by default in your app. This backs up most of your app content, including the RevenueCat SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles).
+Auto Backup is enabled by default in your app. This backs up most of your app content, including the RevenueCat SharedPreferences file, up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles).
 
 We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the RevenueCat SharedPreferences file is included.
 

--- a/docs/getting-started/restoring-purchases.mdx
+++ b/docs/getting-started/restoring-purchases.mdx
@@ -60,13 +60,23 @@ Consumables and non-renewing subscriptions can only be restored by using an acco
 
 By logging in your users with a custom App User ID, RevenueCat can continue to provide transaction details in a user's [CustomerInfo](/customers/customer-info) for their previous consumable and non-renewing subscription purchases.
 
-## Issues restoring One time purchases with Google's Billing Client 8 when using anonymous users
+## Issues restoring one-time purchases with Google's Billing Client 8 when using anonymous users
 
-Starting on Billing Client 8, Google removed the ability to query consumed one time purchases through Google's Billing Client library. This means that our SDK won't be able to restore these purchases.
+Starting on Billing Client 8, Google removed the ability to query consumed one-time purchases through Google's Billing Client library. This means that our SDKs using that version of Billing Client won't be able to restore these purchases. This affects the following versions:
+
+| RevenueCat SDK           | Version using Billing Client 8+                | 
+| :----------------------- | :--------------------------------------------- |
+| purchases-android        | 9.0.0 and up                                   |
+| react-native-purchases   | 9.0.0 and up                                   | 
+| purchases-flutter        | 9.0.0 and up                                   | 
+| cordova-plugin-purchases | 7.0.0 and up                                   |
+| purchases-unity          | 8.0.0 and up                                   |
+| purchases-capacitor      | 11.0.0 and up                                  |
+| purchases-kmp            | 2.0.0 and up                                   |
 
 This can be problematic if both:
 - Your app DOESN'T offer an account system (so users can't log in to recover their purchases) and you rely on RevenueCat's anonymous users AND
-- Your app has or had at any point in time used one time products that were consumed. RevenueCat automatically consumes purchases for products that are configured as consumables in the RevenueCat dashboard.
+- Your app has or had at any point in time used one-time products that were consumed. RevenueCat automatically consumes purchases for products that are configured as consumables in the RevenueCat dashboard.
 
 In this scenario, these users will have anonymous user ids that won't be easily recoverable and won't be able to recover their purchases through the Billing Client, so those purchases can not be recovered.
 

--- a/docs/getting-started/restoring-purchases.mdx
+++ b/docs/getting-started/restoring-purchases.mdx
@@ -60,6 +60,51 @@ Consumables and non-renewing subscriptions can only be restored by using an acco
 
 By logging in your users with a custom App User ID, RevenueCat can continue to provide transaction details in a user's [CustomerInfo](/customers/customer-info) for their previous consumable and non-renewing subscription purchases.
 
+## Issues restoring One time purchases with Google's Billing Client 8 when using anonymous users
+
+Starting on Billing Client 8, Google removed the ability to query consumed one time purchases through Google's Billing Client library. This means that our SDK won't be able to restore these purchases.
+
+This can be problematic if both:
+- Your app DOESN'T offer an account system (so users can't log in to recover their purchases) and you rely on RevenueCat's anonymous users AND
+- Your app has or had at any point in time used one time products that were consumed. RevenueCat automatically consumes purchases for products that are configured as consumables in the RevenueCat dashboard.
+
+In this scenario, these users will have anonymous user ids that won't be easily recoverable and won't be able to recover their purchases through the Billing Client, so those purchases can not be recovered.
+
+One way to reduce the impact of this issue is by making sure RevenueCat's data is safely backed up in the user's Google account, so it is automatically restored when the user reinstalls the app and/or changes devices. RevenueCat stores data in its own SharedPreferences file. The exact name of that file is available as the constant `RevenueCatBackupAgent.REVENUECAT_PREFS_FILE_NAME`, which you can reference when setting up backups. We recommend you also include your app's default SharedPreferences file. 
+
+There are 2 recommended approaches Google offers to perform backups:
+- [Auto Backup](https://developer.android.com/identity/data/autobackup)
+- [Key-value backups](https://developer.android.com/identity/data/keyvaluebackup). 
+
+#### Auto Backup
+Auto Backup is enabled by default in your app. This backs up most of your app content, including the RevenueCat SharedPreferences files up to a 25MB limit, at which point, it stops doing backups. You can configure what you want to backup following [the official documentation](https://developer.android.com/identity/data/autobackup#IncludingFiles).
+
+We recommend adjusting the files you want to back up to make sure you don't go over the limit and making sure the RevenueCat SharedPreferences file is included.
+
+#### Key-Value backups
+Please note that enabling this will disable Auto backup and will just back up RevenueCat files!
+
+If you prefer to disable auto-backup and just back up the RevenueCat SharedPreferences file, you may optionally use our provided `RevenueCatBackupAgent` to perform a backup of the relevant files. To do this, you need to add to your app's `AndroidManifest.xml` `<application>` node a property like this:
+
+```xml
+android:backupAgent="com.revenuecat.purchases.backup.RevenueCatBackupAgent"
+```
+
+### What should you do?
+For the majority of apps, Auto Backup is enabled by default and should handle backups for you without doing anything. However, there are some situations where it won't:
+- If your app has the potential of having more than 25MB of data over the files that Auto Backup automatically backs up (See [docs](https://developer.android.com/identity/data/autobackup#Files))
+- If you have modified the files you would like to backup using Auto Backup and have not included RevenueCat's SharedPreferences file.
+- If you have disabled backups
+
+If you are in one of those positions, we recommend you make sure your backup configuration includes the RevenueCat SharedPreferences file without going over the 25MB limit, or, in case you have backups disabled, you may enable auto backup only for this file or just add the `RevenueCatBackupAgent` to your AndroidManifest.xml application, as mentioned above.
+
+Both options are powered by similar Google backup mechanisms and either should work pretty similarly, so we recommend using Auto Backup unless there is a reason you prefer to use a Backup Agent.
+
+### How to test backups
+Whether you're using Auto Backup or Key-Value backups, Google provides some documentation on how to test backups and restores [in their documentation](https://developer.android.com/identity/data/testingbackup).
+
+One thing to note, however, is that these backups are not guaranteed to work across all devices and might require factory resets in the target device to use the backup.
+
 ## Next Steps
 
 - Make sure all purchases are being [linked to the correct App User ID](/customers/user-ids)


### PR DESCRIPTION
## Motivation / Description
This adds some information to the RevenueCat installation docs about how to setup the app's backup system to make sure to backup RevenueCat data correctly, to minimize lost purchases that needs to be restored (when possible), or that may be lost on the migration to BC8 

## Changes introduced

## Linear ticket (if any)

## Additional comments
