### PR TITLE
Update setup.mdx to include VSCode MCP authentication setup

### DIFF
--- a/docs/tools/mcp/setup.mdx
+++ b/docs/tools/mcp/setup.mdx
@@ -63,20 +63,47 @@ Or you can also add it manually by adding the following to your `mcp.json` file:
 
 Add to your Visual Studio Code `mcp.json`:
 
+#### Option 1: Hardcoded
+
 ```json
 {
-	"servers": {
-		"revenuecat-mcp": {
-			"url": "https://mcp.revenuecat.ai/mcp",
-			"type": "http",
-			"headers": {
-                "Authorization": "Bearer {your API v2 token}"
-			}
-		}
-	},
-	"inputs": []
+  "servers": {
+    "revenuecat-mcp": {
+      "url": "https://mcp.revenuecat.ai/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer {your API v2 token}"
+      }
+    }
+  },
+  "inputs": []
 }
 ```
+
+#### Option 2: Input Parameter (Recommended)
+
+```json
+{
+  "servers": {
+    "revenuecat-mcp": {
+      "url": "https://mcp.revenuecat.ai/mcp",
+      "type": "http",
+      "headers": {
+        "Authorization": "Bearer ${input:revenuecat-bearer-token}"
+      }
+    }
+  },
+  "inputs": [
+    {
+      "type": "promptString",
+      "id": "revenuecat-bearer-token",
+      "description": "RevenueCat Bearer Access Token",
+      "password": true
+    }
+  ]
+}
+```
+
 
 ### Using with Claude Desktop
 

--- a/docs/tools/mcp/setup.mdx
+++ b/docs/tools/mcp/setup.mdx
@@ -68,7 +68,10 @@ Add to your Visual Studio Code `mcp.json`:
 	"servers": {
 		"revenuecat-mcp": {
 			"url": "https://mcp.revenuecat.ai/mcp",
-			"type": "http"
+			"type": "http",
+			"headers": {
+                "Authorization": "Bearer {your API v2 token}"
+			}
 		}
 	},
 	"inputs": []


### PR DESCRIPTION
## Motivation / Description

The current setup instructions for configuring MCP in VSCode with RevenueCat do not mention including the authentication header. This PR updates the documentation to ensure developers correctly set the `Authorization` header with their API v2 token.
See [RevenueCat MCP Server Setup](https://www.revenuecat.com/docs/tools/mcp/setup#using-with-vs-code-copilot)

## Changes introduced

- Updated the configuration documentation to include two options:
  - **Option 1**: Hardcoded token
  - **Option 2**: Input parameter with with  proper `inputs` configuration

## Linear ticket (if any)

N/A

## Additional comments

- Both configuration examples have been tested locally in VSCode with Copilot MCP setup
