### PR TITLE
Clarified which product ID is required for the Google defer endpoint

### DIFF
--- a/openapi-spec/api-v1.yaml
+++ b/openapi-spec/api-v1.yaml
@@ -638,7 +638,7 @@ paths:
           in: path
           description:
             The identifier of the product belonging to the subscription that
-            is being deferred.
+            is being deferred. This can be found in RevenueCat's Product catalog -> <product> -> Subscription Id.
           schema:
             type: string
           required: true


### PR DESCRIPTION
It's super confusing which ID is required for the Google Play defer endpoint. This clarifies that the Subscription Id in the product catalog -> product is what we need.