### PR TITLE
Fix ugly formatting

### DIFF
--- a/openapi-spec/api-v1.yaml
+++ b/openapi-spec/api-v1.yaml
@@ -638,7 +638,7 @@ paths:
           in: path
           description:
             The identifier of the product belonging to the subscription that
-            is being deferred. This can be found in RevenueCat's Product catalog -> <product> -> Subscription Id.
+            is being deferred. This can be found in RevenueCat's Product catalog -> {Product} -> Subscription Id.
           schema:
             type: string
           required: true


### PR DESCRIPTION
It looks like in this [PR](https://github.com/RevenueCat/docs/pull/1132) I just made, the **product** in `RevenueCat's Product catalog -> <product> -> Subscription Id.` was stripped:

<img width="709" height="232" alt="Screenshot 2025-09-10 at 3 18 09 PM" src="https://github.com/user-attachments/assets/e072d95b-b0a7-47eb-9730-9231198f9aac" />

Hopefully this renders ok