### PR TITLE
Use non-deprecated APIs in Customer Center Event Sample Code

### DIFF
--- a/code_blocks/tools/customer-center-events.swift
+++ b/code_blocks/tools/customer-center-events.swift
@@ -1,10 +1,28 @@
-CustomerCenterView { customerCenterAction in
-    switch customerCenterAction {
-    case .restoreStarted:
-    case .restoreFailed(_):
-    case .restoreCompleted(_):
-    case .showingManageSubscriptions:
-    case .refundRequestStarted(_):
-    case .refundRequestCompleted(_):
+CustomerCenterView()
+    .onCustomerCenterRestoreStarted {
+        // TODO: Handle restore started
     }
-}
+    .onCustomerCenterRestoreFailed { error in
+        // TODO: Handle error
+    }
+    .onCustomerCenterRestoreCompleted { customerInfo in
+        // TODO: Handle restore completed
+    }
+    .onCustomerCenterShowingManageSubscriptions {
+        // TODO: Handle showing manage subscriptions
+    }
+    .onCustomerCenterRefundRequestStarted { productId in
+        // TODO: Handle refund request started
+    }
+    .onCustomerCenterRefundRequestCompleted { productId, status in
+        // TODO: Handle refund request completed
+    }
+    .onCustomerCenterFeedbackSurveyCompleted { optionId in
+        // TODO: Handle feedback survey completed
+    }
+    .onCustomerCenterManagementOptionSelected { managementOption in
+        // TODO: Handle Customer Center management option selected
+    }
+    .onCustomerCenterCustomActionSelected { actionIdentifier, purchaseIdentifier in
+        // TODO: Handle custom action selected
+    }

--- a/docs/tools/customer-center/customer-center-integration-ios.mdx
+++ b/docs/tools/customer-center/customer-center-integration-ios.mdx
@@ -88,16 +88,6 @@ import customerCenterEvents from '@site/code_blocks/tools/customer-center-events
   tabs={[{ type: "swift", content: customerCenterEvents, name: "Swift" }]}
 />
 
-If using the modifier:
-
-import customerCenterEventsModifier from '@site/code_blocks/tools/customer-center-events-modifier.swift?raw';
-
-<RCCodeBlock
-  tabs={[
-    { type: "swift", content: customerCenterEventsModifier, name: "Swift" },
-  ]}
-/>
-
 ### Custom Actions
 
 :::info Custom Actions support


### PR DESCRIPTION
## Changes introduced
The existing code samples showing how to handle events from the Customer Center on iOS are outdated and don't compile when using the latest SDK:

<img width="2522" height="1062" alt="image" src="https://github.com/user-attachments/assets/79f6de80-d10e-459d-9f69-a54dc2cd3d55" />

This PR updates the code sample to use the updated APIs for event handling.

