### PR TITLE
fix tiny typo in subscription retention query

### DIFF
--- a/code_blocks/integrations/scheduled-data-exports_14.pgsql
+++ b/code_blocks/integrations/scheduled-data-exports_14.pgsql
@@ -80,7 +80,7 @@ retention AS (
         subs.rc_original_app_user_id = ft.rc_original_app_user_id AND
         subs.product_identifier = ft.product_identifier
     INNER JOIN calculated_product_duration cpd ON 
-        cpd.rc_original_app_user_id = ft.rc_original_app_user_id
+        cpd.rc_original_app_user_id = ft.rc_original_app_user_id AND
         cpd.product_identifier = ft.product_identifier
     WHERE period_number IS NOT NULL
     GROUP BY 1, 2, 3, 4
@@ -106,7 +106,7 @@ pending_retention AS (
         subs.rc_original_app_user_id = ft.rc_original_app_user_id AND
         subs.product_identifier = ft.product_identifier
     INNER JOIN calculated_product_duration cpd ON 
-        cpd.rc_original_app_user_id = ft.rc_original_app_user_id
+        cpd.rc_original_app_user_id = ft.rc_original_app_user_id AND
         cpd.product_identifier = ft.product_identifier
     WHERE unsubscribe_detected_at IS NOT NULL /* count only subscriptions that are set to renew */
         AND

--- a/code_blocks/integrations/scheduled-data-exports_14.pgsql
+++ b/code_blocks/integrations/scheduled-data-exports_14.pgsql
@@ -72,7 +72,7 @@ retention AS (
             WHEN calculated_product_duration = 'P2M' THEN CAST(ROUND(DATE_DIFF('day', subs.first_start_time, start_time) / CAST(60 AS NUMERIC)) AS INTEGER)
             WHEN calculated_product_duration = 'P3M' THEN CAST(ROUND(DATE_DIFF('day', subs.first_start_time, start_time) / CAST(90 AS NUMERIC)) AS INTEGER)
             WHEN calculated_product_duration = 'P6M' THEN CAST(ROUND(DATE_DIFF('day', subs.first_start_time, start_time) / CAST(180 AS NUMERIC)) AS INTEGER)
-            WHEN calculated_product_duration = 'P1Y' THEN CAST(ROUND(DATE_DIFF('month,' subs.first_start_time, start_time) / CAST(12 AS NUMERIC)) AS INTEGER)
+            WHEN calculated_product_duration = 'P1Y' THEN CAST(ROUND(DATE_DIFF('month', subs.first_start_time, start_time) / CAST(12 AS NUMERIC)) AS INTEGER)
         END AS period_number,
         count(1) AS subscriptions
     FROM filtered_transactions ft


### PR DESCRIPTION
## Motivation / Description

teeny tiny typo in the query where the comma was inside of the quotes and missing ANDs in the joins

## Changes introduced

## Linear ticket (if any)

## Additional comments
