### PR TITLE
Gui/update mcp docs

### DIFF
--- a/docs/tools/mcp/setup.mdx
+++ b/docs/tools/mcp/setup.mdx
@@ -93,6 +93,19 @@ Add to your Claude Desktop configuration:
 
 Add to your Codex CLI configuration file (`~/.codex/config.toml`):
 
+**macOS/Linux:**
+
+```toml
+[mcp_servers.revenuecat]
+command = "npx"
+args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
+env = { AUTH_TOKEN = "YOUR_API_V2_SECRET_KEY" }
+type = "stdio"
+startup_timeout_ms = 20_000
+```
+
+**Windows:**
+
 ```toml
 [mcp_servers.revenuecat]
 command = 'C:\Program Files\nodejs\npx.cmd'
@@ -108,7 +121,7 @@ type = "stdio"
 startup_timeout_ms = 20_000
 ```
 
-> **💡 Note**: Replace `USERNAME` with your actual Windows username. On Unix/Linux/macOS, you can use `command = "npx"` instead of the full Windows path.
+> **💡 Note**: On Windows, replace `USERNAME` with your actual Windows username.
 
 ### Using with MCP Inspector
 

--- a/docs/tools/mcp/setup.mdx
+++ b/docs/tools/mcp/setup.mdx
@@ -89,6 +89,38 @@ Add to your Claude Desktop configuration:
 }
 ```
 
+### Using with OpenAI Codex CLI
+
+Add to your Codex CLI configuration file (`~/.codex/config.toml`):
+
+```toml
+[mcp_servers.revenuecat]
+command = "npx"
+args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
+env = { AUTH_TOKEN = "YOUR_API_V2_SECRET_KEY" }
+type = "stdio"
+startup_timeout_ms = 20_000
+```
+
+**For Windows users**, you may need to specify the full path to npx:
+
+```toml
+[mcp_servers.revenuecat]
+command = 'C:\Program Files\nodejs\npx.cmd'
+args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
+env = {
+    APPDATA = 'C:\Users\USERNAME\AppData\Roaming',
+    LOCALAPPDATA = 'C:\Users\USERNAME\AppData\Local',
+    HOME = 'C:\Users\USERNAME',
+    SystemRoot = 'C:\Windows',
+    AUTH_TOKEN = "YOUR_API_V2_SECRET_KEY"
+}
+type = "stdio"
+startup_timeout_ms = 20_000
+```
+
+> **💡 Note**: Replace `USERNAME` with your actual Windows username in the environment paths.
+
 ### Using with MCP Inspector
 
 For testing and development:

--- a/docs/tools/mcp/setup.mdx
+++ b/docs/tools/mcp/setup.mdx
@@ -95,17 +95,6 @@ Add to your Codex CLI configuration file (`~/.codex/config.toml`):
 
 ```toml
 [mcp_servers.revenuecat]
-command = "npx"
-args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
-env = { AUTH_TOKEN = "YOUR_API_V2_SECRET_KEY" }
-type = "stdio"
-startup_timeout_ms = 20_000
-```
-
-**For Windows users**, you may need to specify the full path to npx:
-
-```toml
-[mcp_servers.revenuecat]
 command = 'C:\Program Files\nodejs\npx.cmd'
 args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
 env = {
@@ -119,7 +108,7 @@ type = "stdio"
 startup_timeout_ms = 20_000
 ```
 
-> **💡 Note**: Replace `USERNAME` with your actual Windows username in the environment paths.
+> **💡 Note**: Replace `USERNAME` with your actual Windows username. On Unix/Linux/macOS, you can use `command = "npx"` instead of the full Windows path.
 
 ### Using with MCP Inspector
 


### PR DESCRIPTION
## Motivation / Description

Customer ticket [here](https://revenuecat.zendesk.com/agent/tickets/64735) saying that the community was struggling and the docs could be updated. 

```
here is the code that worked for me on windows.

[mcp_servers.revenuecat]
command = 'C:\Program Files\nodejs\npx.cmd'

args = ["mcp-remote", "https://mcp.revenuecat.ai/mcp", "--header", "Authorization: Bearer ${AUTH_TOKEN}"]
env = { APPDATA = 'C:\Users\MASTERPROJECT\AppData\Roaming',LOCALAPPDATA = 'C:\Users\MASTERPROJECT\AppData\Local',HOME = 'C:\Users\MASTERPROJECT',SystemRoot = 'C:\Windows',AUTH_TOKEN = "YOUR_AUTH_TOKEN"}

type = "stdio"

startup_timeout_ms = 20_000
```

## Changes introduced

New section in `docs/tools/mcp/setup#using-with-openai-codex-cli` with this. CC™ powered:

<img width="925" height="703" alt="Screenshot 2025-09-30 at 11 25 34" src="https://github.com/user-attachments/assets/78b38fcc-0b62-495f-b33b-b4d0ef2df4c5" />




## Linear ticket (if any)

## Additional comments
