### PR TITLE
Be explicit in win-back offers and unapproved products.

### DIFF
--- a/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
+++ b/docs/subscription-guidance/subscription-offers/ios-subscription-offers.mdx
@@ -179,7 +179,7 @@ Apple introduced win-back offers with iOS 18, which allow developers to provide 
 ### 1. Configuring a Win-Back Offer
 
 :::warning
-Win-Back Offers can only be configured for subscription products that have been approved by App Review. Please ensure that your subscription product has been approved by App Review before proceeding.
+Win-Back Offers can only be configured for subscription products that have been approved by App Review. Please ensure that your subscription product has been approved by App Review before setting up a Win-Back offer for it.
 :::
 
 Navigate to your subscription's page under _Apps_ → _Your App_ → _Subscriptions_ (in the left sidebar) → _Your Subscription Group_ → _Your Subscription Product_ and click the "+" button by "Subscription Prices". If your subscription product has been approved by App Review, you'll see the option "Create Win-Back Offer". Select it.


### PR DESCRIPTION
## Motivation / Description

Apple Review team seems to be getting many RC developers who seem to misunderstand the IAP approval and sandbox usage. They have flagged a few old articles and this sentence in win-back offers seem to cause a few problems as well. 

## Changes introduced

Change the wording of the warning to be clearly state that this warning only applies to win-back offers and not IAP in general. 

## Linear ticket (if any)

## Additional comments
