### PR TITLE
Markdown docs for LLMs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -130,6 +130,7 @@ const config = {
         anonymizeIP: true,
       },
     ],
+    "./src/plugins/markdown-alternates/index.js",
     "./src/plugins/tailwind/tailwind-config.cjs",
     function myRawLoaderPlugin() {
       // this plugin replaces raw-loader with asset/source (webpack 5)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,11 @@
     "prism-react-renderer": "^2.4.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
-    "redocusaurus": "^2.5.0"
+    "redocusaurus": "^2.5.0",
+    "unified": "^11.0.4",
+    "remark-parse": "^11.0.0",
+    "remark-mdx": "^3.0.1",
+    "remark-stringify": "^11.0.0"
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "^3.8.1",

--- a/src/plugins/markdown-alternates/frontMatter.js
+++ b/src/plugins/markdown-alternates/frontMatter.js
@@ -1,0 +1,56 @@
+function escapeYaml(value) {
+  if (value === null || value === undefined || value === "") {
+    return "";
+  }
+
+  const strValue = String(value).replace(/"/g, '\\"');
+  return `"${strValue}"`;
+}
+
+function serializeArray(key, values) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return "";
+  }
+
+  const filtered = values
+    .map((value) => escapeYaml(value))
+    .filter((value) => value !== "");
+
+  if (!filtered.length) {
+    return "";
+  }
+
+  const serialized = filtered.map((value) => `  - ${value}`).join("\n");
+
+  return `${key}:\n${serialized}`;
+}
+
+export function createFrontMatterBlock(frontMatter) {
+  const lines = [];
+
+  for (const [key, value] of Object.entries(frontMatter)) {
+    if (value === undefined || value === null) {
+      continue;
+    }
+
+    if (Array.isArray(value)) {
+      const serializedArray = serializeArray(key, value);
+      if (serializedArray) {
+        lines.push(serializedArray);
+      }
+      continue;
+    }
+
+    const escaped = escapeYaml(value);
+    if (escaped === "") {
+      continue;
+    }
+    lines.push(`${key}: ${escaped}`);
+  }
+
+  if (!lines.length) {
+    return "";
+  }
+
+  return `---\n${lines.join("\n")}\n---\n\n`;
+}

--- a/src/plugins/markdown-alternates/index.js
+++ b/src/plugins/markdown-alternates/index.js
@@ -236,23 +236,15 @@ function permalinkToOutputPaths(
   const trimmedRelative = trimmed.replace(/^\/+/, "");
   const markdownPublicPath = (() => {
     if (hasTrailingSlash) {
-      if (!trimmedRelative) {
-        return `/index${markdownExtension}`;
-      }
-      return `/${trimmedRelative}/index${markdownExtension}`;
+      return `${permalink}index${markdownExtension}`;
     }
 
-    if (!trimmedRelative) {
+    if (!permalink || permalink === "/") {
       return `/index${markdownExtension}`;
     }
 
-    return `/${trimmedRelative}${markdownExtension}`;
+    return `${permalink}${markdownExtension}`;
   })();
-
-  const markdownPath = path.join(
-    outDir,
-    markdownPublicPath.replace(/^\/+/, ""),
-  );
 
   const normalizedBase = (baseUrl || "/")
     .replace(/^\/+/, "")
@@ -265,19 +257,34 @@ function permalinkToOutputPaths(
     routePath = "";
   }
 
-  let htmlPath;
-  if (!routePath) {
-    htmlPath = path.join(outDir, "index.html");
-  } else if (trailingSlash) {
-    htmlPath = path.join(outDir, routePath, "index.html");
-  } else {
-    htmlPath = path.join(outDir, `${routePath}.html`);
-  }
+  const htmlRelativePath = (() => {
+    if (!routePath) {
+      return "index.html";
+    }
+
+    if (trailingSlash) {
+      return path.join(routePath, "index.html");
+    }
+
+    return `${routePath}.html`;
+  })();
+
+  const markdownRelativePath = (() => {
+    if (!routePath) {
+      return `index${markdownExtension}`;
+    }
+
+    if (hasTrailingSlash || trailingSlash) {
+      return path.join(routePath, `index${markdownExtension}`);
+    }
+
+    return `${routePath}${markdownExtension}`;
+  })();
 
   return {
-    markdownPath,
+    markdownPath: path.join(outDir, markdownRelativePath),
     markdownPublicPath,
-    htmlPath,
+    htmlPath: path.join(outDir, htmlRelativePath),
   };
 }
 

--- a/src/plugins/markdown-alternates/index.js
+++ b/src/plugins/markdown-alternates/index.js
@@ -1,0 +1,455 @@
+import path from "node:path";
+import fs from "node:fs";
+import { promises as fsPromises } from "node:fs";
+
+import { mdxToMarkdown } from "./mdxToMarkdown.js";
+import { createFrontMatterBlock } from "./frontMatter.js";
+
+const DEFAULT_OPTIONS = {
+  docsPluginId: "default",
+  markdownExtension: ".md",
+  fallbackText:
+    "Interactive content is available in the web version of this doc.",
+  videoText: "Watch the video content in the hosted documentation.",
+};
+
+async function fileExists(targetPath) {
+  try {
+    await fsPromises.access(targetPath);
+    return true;
+  } catch (error) {
+    if ((error?.code ?? "") === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function resolveSourcePath(siteDir, source) {
+  if (!source) {
+    return null;
+  }
+
+  if (source.startsWith("@site/")) {
+    return path.join(siteDir, source.replace(/^@site\//, ""));
+  }
+
+  if (path.isAbsolute(source)) {
+    return source;
+  }
+
+  return path.join(siteDir, source);
+}
+
+async function collectDocMetadata(context, docsPluginId) {
+  const pluginDir = path.join(
+    context.generatedFilesDir,
+    "docusaurus-plugin-content-docs",
+    docsPluginId,
+  );
+
+  async function gatherMetadataFiles(dir, accumulator) {
+    const entries = await fsPromises.readdir(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const entryPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await gatherMetadataFiles(entryPath, accumulator);
+      } else if (
+        entry.isFile() &&
+        entry.name.startsWith("site-docs") &&
+        entry.name.endsWith(".json")
+      ) {
+        accumulator.push(entryPath);
+      }
+    }
+  }
+
+  const metadataFiles = [];
+  try {
+    await gatherMetadataFiles(pluginDir, metadataFiles);
+  } catch (error) {
+    if ((error?.code ?? "") === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+
+  const records = [];
+
+  for (const filePath of metadataFiles) {
+    try {
+      const raw = await fsPromises.readFile(filePath, "utf8");
+      const doc = JSON.parse(raw);
+      if (!doc.permalink || !doc.source) {
+        continue;
+      }
+
+      const absoluteSourcePath = resolveSourcePath(context.siteDir, doc.source);
+      const tags = Array.isArray(doc.tags)
+        ? doc.tags.map((tag) =>
+            typeof tag === "string"
+              ? tag
+              : typeof tag?.label === "string"
+                ? tag.label
+                : "",
+          )
+        : [];
+
+      records.push({
+        id: doc.id,
+        title: doc.title,
+        description: doc.description,
+        permalink: doc.permalink,
+        tags,
+        frontMatter: doc.frontMatter ?? {},
+        sourcePath: absoluteSourcePath,
+        sidebar: doc.sidebar,
+        sidebarPosition: doc.sidebarPosition,
+        versionName: doc.version,
+      });
+    } catch (error) {
+      console.warn(
+        `Failed to process doc metadata at ${filePath}: ${error.message}`,
+      );
+    }
+  }
+
+  return records;
+}
+
+async function ensureAlternateLink(htmlPath, markdownHref) {
+  try {
+    const html = await fsPromises.readFile(htmlPath, "utf8");
+    if (html.includes(`rel="alternate"`) && html.includes(markdownHref)) {
+      return;
+    }
+
+    const linkTag = `<link rel="alternate" type="text/markdown" href="${markdownHref}">`;
+    if (html.includes(linkTag)) {
+      return;
+    }
+
+    const closingHeadIndex = html.indexOf("</head>");
+    let anchorIndex = closingHeadIndex;
+
+    if (anchorIndex === -1) {
+      anchorIndex = html.indexOf("<body");
+    }
+
+    if (anchorIndex === -1) {
+      return;
+    }
+
+    const updatedHtml =
+      html.slice(0, anchorIndex) + `${linkTag}` + html.slice(anchorIndex);
+
+    await fsPromises.writeFile(htmlPath, updatedHtml, "utf8");
+  } catch (error) {
+    if ((error?.code ?? "") !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function writeLinkHeadersManifest(outDir, docs) {
+  if (!docs.length) {
+    return;
+  }
+
+  const headersPath = path.join(outDir, "_headers");
+  let existing = "";
+
+  try {
+    existing = await fsPromises.readFile(headersPath, "utf8");
+  } catch (error) {
+    if ((error?.code ?? "") !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  const seen = new Set();
+  const lines = ["# Markdown alternate representations"];
+
+  for (const doc of docs) {
+    if (!doc.permalink || seen.has(doc.permalink)) {
+      continue;
+    }
+
+    seen.add(doc.permalink);
+    lines.push(doc.permalink);
+    lines.push(
+      `  Link: <${doc.markdownHref}>; rel="alternate"; type="text/markdown"`,
+    );
+    lines.push("");
+  }
+
+  if (lines.length <= 1) {
+    return;
+  }
+
+  if (lines[lines.length - 1] === "") {
+    lines.pop();
+  }
+
+  const trimmedExisting = existing.trimEnd();
+  const merged = [trimmedExisting, lines.join("\n")]
+    .filter((value) => value && value.length > 0)
+    .join("\n\n");
+
+  await fsPromises.writeFile(headersPath, `${merged}\n`, "utf8");
+}
+
+async function writeMetadataSummary(outDir, docs) {
+  if (!docs.length) {
+    return;
+  }
+
+  const summaryPath = path.join(outDir, "markdown-alternates.json");
+  const payload = {
+    generatedAt: new Date().toISOString(),
+    count: docs.length,
+    docs: docs.map((doc) => ({
+      permalink: doc.permalink,
+      markdownHref: doc.markdownHref,
+      markdownPath: doc.markdownPath,
+      markdownPublicPath: doc.markdownPublicPath,
+      htmlPath: doc.htmlPath,
+    })),
+  };
+
+  await fsPromises.writeFile(
+    summaryPath,
+    JSON.stringify(payload, null, 2),
+    "utf8",
+  );
+}
+
+function permalinkToOutputPaths(
+  outDir,
+  permalink,
+  markdownExtension,
+  baseUrl,
+  trailingSlash,
+) {
+  const hasTrailingSlash = permalink.endsWith("/");
+  const trimmed = permalink.replace(/\/+$/, "");
+  const trimmedRelative = trimmed.replace(/^\/+/, "");
+  const markdownPublicPath = (() => {
+    if (hasTrailingSlash) {
+      if (!trimmedRelative) {
+        return `/index${markdownExtension}`;
+      }
+      return `/${trimmedRelative}/index${markdownExtension}`;
+    }
+
+    if (!trimmedRelative) {
+      return `/index${markdownExtension}`;
+    }
+
+    return `/${trimmedRelative}${markdownExtension}`;
+  })();
+
+  const markdownPath = path.join(
+    outDir,
+    markdownPublicPath.replace(/^\/+/, ""),
+  );
+
+  const normalizedBase = (baseUrl || "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "");
+  let routePath = trimmedRelative;
+
+  if (normalizedBase && routePath.startsWith(`${normalizedBase}/`)) {
+    routePath = routePath.slice(normalizedBase.length + 1);
+  } else if (normalizedBase && routePath === normalizedBase) {
+    routePath = "";
+  }
+
+  let htmlPath;
+  if (!routePath) {
+    htmlPath = path.join(outDir, "index.html");
+  } else if (trailingSlash) {
+    htmlPath = path.join(outDir, routePath, "index.html");
+  } else {
+    htmlPath = path.join(outDir, `${routePath}.html`);
+  }
+
+  return {
+    markdownPath,
+    markdownPublicPath,
+    htmlPath,
+  };
+}
+
+export default function markdownAlternatesPlugin(context, opts = {}) {
+  const options = { ...DEFAULT_OPTIONS, ...opts };
+
+  return {
+    name: "revenuecat-markdown-alternates",
+
+    async postBuild({ outDir }) {
+      const docs = await collectDocMetadata(context, options.docsPluginId);
+      if (!docs.length) {
+        return;
+      }
+
+      const siteUrl = context.siteConfig?.url ?? "";
+      const generatedDocs = [];
+
+      for (const doc of docs) {
+        const { markdownPath, markdownPublicPath, htmlPath } =
+          permalinkToOutputPaths(
+            outDir,
+            doc.permalink,
+            options.markdownExtension,
+            context.siteConfig?.baseUrl ?? "/",
+            context.siteConfig?.trailingSlash ?? undefined,
+          );
+
+        if (!doc.sourcePath) {
+          continue;
+        }
+
+        const sourceExists = fs.existsSync(doc.sourcePath);
+        if (!sourceExists) {
+          continue;
+        }
+
+        const rawMdx = await fsPromises.readFile(doc.sourcePath, "utf8");
+        const markdownBody = await mdxToMarkdown(rawMdx, {
+          fallbackText: options.fallbackText,
+          videoText: options.videoText,
+        });
+
+        const relativeSource = path.relative(context.siteDir, doc.sourcePath);
+        const slugCandidate = doc.frontMatter?.slug
+          ? String(doc.frontMatter.slug)
+          : doc.permalink.replace(/^\/+/, "");
+
+        const frontMatterBlock = createFrontMatterBlock({
+          id: doc.id,
+          title: doc.title,
+          description: doc.description,
+          permalink: doc.permalink,
+          slug: slugCandidate,
+          version: doc.versionName,
+          original_source: relativeSource,
+          tags: doc.tags,
+          keywords: Array.isArray(doc.frontMatter?.keywords)
+            ? doc.frontMatter.keywords
+            : undefined,
+        });
+
+        const dir = path.dirname(markdownPath);
+        await fsPromises.mkdir(dir, { recursive: true });
+        await fsPromises.writeFile(
+          markdownPath,
+          `${frontMatterBlock}${markdownBody}\n`,
+          "utf8",
+        );
+
+        const markdownHref = siteUrl
+          ? new URL(markdownPublicPath, siteUrl).toString()
+          : markdownPublicPath;
+
+        await ensureAlternateLink(htmlPath, markdownHref);
+
+        generatedDocs.push({
+          permalink: doc.permalink,
+          markdownPath,
+          markdownPublicPath,
+          markdownHref,
+          htmlPath,
+        });
+      }
+
+      await writeLinkHeadersManifest(outDir, generatedDocs);
+      await writeMetadataSummary(outDir, generatedDocs);
+    },
+
+    extendCli(cli) {
+      cli
+        .command("markdown-alternates:check")
+        .description(
+          "Validate generated markdown alternate files, HTML head tags, and headers",
+        )
+        .option(
+          "--out-dir <path>",
+          "Directory containing the built site",
+          context.outDir,
+        )
+        .action(async (command) => {
+          const outDir = path.resolve(command.outDir);
+          const summaryPath = path.join(outDir, "markdown-alternates.json");
+          let summary;
+
+          try {
+            const raw = await fsPromises.readFile(summaryPath, "utf8");
+            summary = JSON.parse(raw);
+          } catch (error) {
+            console.error(
+              `Unable to read markdown alternate summary at ${summaryPath}: ${error.message}`,
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          const issues = [];
+
+          const headersPath = path.join(outDir, "_headers");
+          let headersContent = "";
+          try {
+            headersContent = await fsPromises.readFile(headersPath, "utf8");
+          } catch (error) {
+            if ((error?.code ?? "") !== "ENOENT") {
+              throw error;
+            }
+          }
+
+          for (const doc of summary.docs ?? []) {
+            const markdownPresent = await fileExists(doc.markdownPath);
+            if (!markdownPresent) {
+              issues.push(
+                `Missing markdown file for ${doc.permalink} (expected at ${doc.markdownPath})`,
+              );
+            }
+
+            try {
+              const html = await fsPromises.readFile(doc.htmlPath, "utf8");
+              if (!html.includes(doc.markdownHref)) {
+                issues.push(
+                  `HTML page ${doc.htmlPath} does not reference ${doc.markdownHref}`,
+                );
+              }
+            } catch (error) {
+              if ((error?.code ?? "") === "ENOENT") {
+                issues.push(
+                  `Missing HTML output for ${doc.permalink} at ${doc.htmlPath}`,
+                );
+              } else {
+                throw error;
+              }
+            }
+
+            if (!headersContent.includes(doc.markdownHref)) {
+              issues.push(
+                `HTTP Link header entry for ${doc.permalink} (${doc.markdownHref}) not found in ${headersPath}`,
+              );
+            }
+          }
+
+          if (issues.length) {
+            console.error(
+              "Markdown alternate checks failed:\n" + issues.join("\n"),
+            );
+            process.exitCode = 1;
+            return;
+          }
+
+          console.log(
+            `Validated ${summary.count ?? summary.docs?.length ?? 0} markdown alternate entries in ${outDir}`,
+          );
+        });
+    },
+  };
+}

--- a/src/plugins/markdown-alternates/mdxToMarkdown.js
+++ b/src/plugins/markdown-alternates/mdxToMarkdown.js
@@ -81,7 +81,7 @@ function createVideoParagraph({ url, videoText }) {
       type: "link",
       url,
       title: null,
-      children: [{ type: "text", value: videoText }],
+      children: [{ type: "text", value: url }],
     });
   } else {
     children.push({ type: "text", value: videoText });

--- a/src/plugins/markdown-alternates/mdxToMarkdown.js
+++ b/src/plugins/markdown-alternates/mdxToMarkdown.js
@@ -1,0 +1,267 @@
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkMdx from "remark-mdx";
+import remarkStringify from "remark-stringify";
+
+const DEFAULT_FALLBACK =
+  "Interactive content is available in the web version of this document.";
+const DEFAULT_VIDEO_TEXT =
+  "Watch the video content in the hosted documentation.";
+
+function stripFrontMatter(source) {
+  if (typeof source !== "string") {
+    return source;
+  }
+
+  if (!source.startsWith("---")) {
+    return source;
+  }
+
+  const closingMarker = source.indexOf("\n---", 3);
+  if (closingMarker === -1) {
+    return source;
+  }
+
+  const afterMarker = closingMarker + "\n---".length;
+  const remainder = source.slice(afterMarker);
+
+  // Remove a single leading newline to avoid blank first line in output.
+  return remainder.startsWith("\n") ? remainder.slice(1) : remainder;
+}
+
+function getAttributeValue(node, attributeName) {
+  const attributes = Array.isArray(node.attributes) ? node.attributes : [];
+  const attribute = attributes.find(
+    (current) =>
+      current.type === "mdxJsxAttribute" && current.name === attributeName,
+  );
+
+  if (!attribute) {
+    return undefined;
+  }
+
+  if (typeof attribute.value === "string") {
+    return attribute.value;
+  }
+
+  if (
+    attribute.value &&
+    typeof attribute.value === "object" &&
+    "value" in attribute.value
+  ) {
+    return String(attribute.value.value);
+  }
+
+  return undefined;
+}
+
+function createFallbackParagraph(text) {
+  return {
+    type: "paragraph",
+    children: [
+      {
+        type: "emphasis",
+        children: [{ type: "text", value: text }],
+      },
+    ],
+  };
+}
+
+function createVideoParagraph({ url, videoText }) {
+  const children = [];
+
+  children.push({
+    type: "strong",
+    children: [{ type: "text", value: "Video:" }],
+  });
+  children.push({ type: "text", value: " " });
+
+  if (url) {
+    children.push({
+      type: "link",
+      url,
+      title: null,
+      children: [{ type: "text", value: videoText }],
+    });
+  } else {
+    children.push({ type: "text", value: videoText });
+  }
+
+  return { type: "paragraph", children };
+}
+
+function isLikelyVideoComponent(node) {
+  const name = node.name ?? "";
+  const urlCandidate =
+    getAttributeValue(node, "src") ||
+    getAttributeValue(node, "source") ||
+    getAttributeValue(node, "url") ||
+    getAttributeValue(node, "href");
+
+  if (/video|youtube|wistia|vimeo|loom/i.test(name)) {
+    return true;
+  }
+
+  if (!urlCandidate) {
+    return false;
+  }
+
+  return (
+    /\.(mp4|webm|mov)(\?|$)/i.test(urlCandidate) ||
+    /youtu|vimeo|loom|wistia/i.test(urlCandidate)
+  );
+}
+
+function transformChildren(children, context) {
+  if (!Array.isArray(children) || !children.length) {
+    return [];
+  }
+
+  const transformed = [];
+
+  for (const child of children) {
+    const result = transformNode(child, context);
+    if (Array.isArray(result)) {
+      transformed.push(...result);
+    } else if (result) {
+      transformed.push(result);
+    }
+  }
+
+  return transformed;
+}
+
+function transformFlowElement(node, context) {
+  if (isLikelyVideoComponent(node)) {
+    const url =
+      getAttributeValue(node, "src") ||
+      getAttributeValue(node, "source") ||
+      getAttributeValue(node, "url") ||
+      getAttributeValue(node, "href");
+    return [createVideoParagraph({ url, videoText: context.videoText })];
+  }
+
+  if (node.name === "Tabs") {
+    const children = transformChildren(node.children, context);
+    return children.length
+      ? children
+      : [createFallbackParagraph(context.fallbackText)];
+  }
+
+  if (node.name === "TabItem") {
+    const label =
+      getAttributeValue(node, "label") ||
+      getAttributeValue(node, "value") ||
+      getAttributeValue(node, "defaultValue");
+
+    const heading = label
+      ? {
+          type: "heading",
+          depth: 4,
+          children: [{ type: "text", value: label }],
+        }
+      : null;
+
+    const content = transformChildren(node.children, context);
+    const nodes = [];
+
+    if (heading) {
+      nodes.push(heading);
+    }
+
+    if (content.length) {
+      nodes.push(...content);
+    }
+
+    if (!nodes.length) {
+      nodes.push(createFallbackParagraph(context.fallbackText));
+    }
+
+    return nodes;
+  }
+
+  const transformedChildren = transformChildren(node.children, context);
+  return transformedChildren.length
+    ? transformedChildren
+    : [createFallbackParagraph(context.fallbackText)];
+}
+
+function transformTextElement(node, context) {
+  const children = transformChildren(node.children, context);
+  if (children.length) {
+    return children;
+  }
+
+  return [
+    {
+      type: "text",
+      value: `(${context.fallbackText})`,
+    },
+  ];
+}
+
+function transformNode(node, context) {
+  if (!node) {
+    return null;
+  }
+
+  switch (node.type) {
+    case "yaml":
+    case "mdxjsEsm":
+      return null;
+    case "mdxFlowExpression":
+      return [createFallbackParagraph(context.fallbackText)];
+    case "mdxTextExpression":
+      return [
+        {
+          type: "text",
+          value: `(${context.fallbackText})`,
+        },
+      ];
+    case "mdxJsxFlowElement":
+      return transformFlowElement(node, context);
+    case "mdxJsxTextElement":
+      return transformTextElement(node, context);
+    default:
+      break;
+  }
+
+  if (Array.isArray(node.children)) {
+    node.children = transformChildren(node.children, context);
+  }
+
+  return node;
+}
+
+function rewriteDynamicContent({ fallbackText, videoText }) {
+  const context = {
+    fallbackText: fallbackText || DEFAULT_FALLBACK,
+    videoText: videoText || DEFAULT_VIDEO_TEXT,
+  };
+
+  return (tree) => {
+    if (!tree || typeof tree !== "object") {
+      return;
+    }
+
+    const rootChildren = Array.isArray(tree.children) ? tree.children : [];
+    tree.children = transformChildren(rootChildren, context);
+  };
+}
+
+export async function mdxToMarkdown(source, options = {}) {
+  const sanitizedSource = stripFrontMatter(source);
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkMdx)
+    .use(rewriteDynamicContent, options)
+    .use(remarkStringify, {
+      fences: true,
+      bullet: "-",
+      listItemIndent: "one",
+    });
+
+  const file = await processor.process(sanitizedSource);
+  return String(file).trim();
+}

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -4,6 +4,10 @@ This file provides an organized guide to RevenueCat's documentation for large la
 
 The prefix for the URL paths is: https://www.revenuecat.com/docs
 
+### Markdown Mirrors
+- Append `.md` to any listed path to fetch the LLM-optimized markdown version, for example `/projects/overview.md` or `/subscription-guidance/subscription-offers/ios-subscription-offers.md`.
+- Markdown mirrors include descriptive fallbacks for interactive content and link back to embedded media.
+
 ## Overview and Getting Started
 
 - /welcome/overview - Platform introduction and core concepts of RevenueCat


### PR DESCRIPTION
## Motivation / Description

Make it easier for LLMs to consume our docs content. 

## Changes introduced

- vibe coded a docusaurus plugin which generates markdown twins for the html content in docs. 
- added a link tag in html head pointing towards the markdown files for discoverability
- added information about markdown content to llms.txt

## Linear ticket (if any)

## Additional comments

TODO: 
we still need to configure two things:
- add a Link HTTP header pointing to the markdown file when an html file is requested
- add some well known AI crawlers/agents User Agents to receive the markdown files by default.

both of the TODOs above require some CloudFront config beyond what we can do with the Azure deploy script. 
