### PR TITLE
Removes mentions of `:purchases-kmp-datetime`.

### DIFF
--- a/code_blocks/getting-started/installation/kmp_1.toml
+++ b/code_blocks/getting-started/installation/kmp_1.toml
@@ -4,8 +4,6 @@ purchases-kmp = "<latest version>"
 [libraries]
 # Required
 purchases-core = { module = "com.revenuecat.purchases:purchases-kmp-core", version.ref = "purchases-kmp" }
-# Optional: adds extension properties representing timestamps as kotlinx-datetime Instants.
-purchases-datetime = { module = "com.revenuecat.purchases:purchases-kmp-datetime", version.ref = "purchases-kmp" }
 # Optional: adds suspending functions that return Arrow's Either to indicate success / failure.
 purchases-either = { module = "com.revenuecat.purchases:purchases-kmp-either", version.ref = "purchases-kmp" }
 # Optional: adds suspending functions that return kotlin.Result to indicate success / failure.

--- a/code_blocks/getting-started/installation/kmp_2.kts
+++ b/code_blocks/getting-started/installation/kmp_2.kts
@@ -5,7 +5,6 @@ kotlin {
         commonMain.dependencies {  
             // Add the purchases-kmp dependencies.
             implementation(libs.purchases.core)  
-            implementation(libs.purchases.datetime)   // Optional
             implementation(libs.purchases.either)     // Optional
             implementation(libs.purchases.result)     // Optional
         }


### PR DESCRIPTION
## Motivation / Description
We have deprecated the `:purchases-kmp-datetime` module in https://github.com/RevenueCat/purchases-kmp/pull/514, so we should no longer direct people to use it. Its functionality has been absorbed into `:purchases-kmp-core`. 

## Changes introduced

## Linear ticket (if any)

## Additional comments
